### PR TITLE
Fixed Controller decorator to be compatible with ClassDecorator signa…

### DIFF
--- a/src/decorator/Controller.ts
+++ b/src/decorator/Controller.ts
@@ -7,7 +7,7 @@ import {getMetadataArgsStorage} from "../index";
  *
  * @param baseRoute Extra path you can apply as a base route to all controller actions
  */
-export function Controller(baseRoute?: string): Function {
+export function Controller(baseRoute?: string) {
     return function (object: Function) {
         getMetadataArgsStorage().controllers.push({
             type: "default",


### PR DESCRIPTION
The declaration file generated for Controller decorator was not compatible with ClassDecorator.

I saw this bug when I tried to use Reflect.decorate() method from reflect-metadata. 