### PR TITLE
Fix: Providing any ValidationOptions in @Body overwrites entirety of defaults set at server level #391

### DIFF
--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -184,7 +184,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
             && (value instanceof paramMetadata.targetType);
 
         if (isValidationEnabled && shouldValidate) {
-            const options = paramMetadata.validate instanceof Object ? paramMetadata.validate : this.driver.validationOptions;
+            const options = Object.assign({}, this.driver.validationOptions, paramMetadata.validate);
             return validate(value, options)
                 .then(() => value)
                 .catch((validationErrors: ValidationError[]) => {


### PR DESCRIPTION
Added the change described in the issue I opened #391 as well as a test to cover.