### PR TITLE
Handle stream errors in Express driver

### DIFF
--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -329,6 +329,7 @@ export class ExpressDriver extends BaseDriver {
             options.response.end(Buffer.from(result as any), "binary");
         }
         else if (result.pipe instanceof Function) {
+            result.on("error", (error: any) => options.next(error));
             result.pipe(options.response);
         }
         else { // send regular result


### PR DESCRIPTION
When the result of an action is a stream, register an error handler on the stream, so that the appropriate Express error handler will be called. Without such an error handler, an error on the stream will make the Node process crash.

For Koa this is not needed, as it automatically registers an error handler when returning a stream: https://github.com/koajs/koa/blob/74170caf0b332dae01fb81cf03145a17df83b6dd/lib/response.js#L170