### PR TITLE
subdomain support koa only

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can use routing-controllers with [express.js][1] or [koa.js][2].
 
     **b. If you want to use routing-controllers with *koa 2*, then install it and all required dependencies:**
 
-    `npm install koa koa-router koa-bodyparser koa-multer --save`
+    `npm install koa koa-router koa-bodyparser koa-multer koa-subdomain --save`
 
     Optionally you can also install their typings:
 
@@ -341,7 +341,7 @@ createExpressServer({
 You can prefix all specific controller's actions with base route:
 
 ```typescript
-@Controller("/users")
+@Controller({ baseRoute: "/users" })
 export class UserController {
     // ...
 }
@@ -1401,8 +1401,9 @@ export class QuestionController {
 
 | Signature                            | Example                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 |--------------------------------------|------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@Controller(baseRoute: string)`     | `@Controller("/users") class SomeController`         | Class that is marked with this decorator is registered as controller and its annotated methods are registered as actions. Base route is used to concatenate it to all controller action routes.                                                                                                                                                                                                                                                      |
-| `@JsonController(baseRoute: string)` | `@JsonController("/users") class SomeJsonController` | Class that is marked with this decorator is registered as controller and its annotated methods are registered as actions. Difference between @JsonController and @Controller is that @JsonController automatically converts results returned by controller to json objects (using JSON.parse) and response being sent to a client is sent with application/json content-type. Base route is used to concatenate it to all controller action routes.  |
+| `@Controller(options: ControllerOptions)`     | `@Controller({ baseRoute: "/users", subdomain: "example" }) class SomeController`         | Class that is marked with this decorator is registered as controller and its annotated methods are registered as actions. Base route is used to concatenate it to all controller action routes. Subdomain is used to register the Controller and its annotated methods only for the specific subdomain.                                                                             |
+| `@JsonController(options: ControllerOptions)` | `@JsonController({ baseRoute: "/users", subdomain: "example" }) class SomeJsonController` | Class that is marked with this decorator is registered as controller and its annotated methods are registered as actions. Difference between @JsonController and @Controller is that @JsonController automatically converts results returned by controller to json objects (using JSON.parse) and response being sent to a client is sent with application/json content-type. Base route is used to concatenate it to all controller action routes.  
+Subdomain is used to register the Controller and its annotated methods only for the specific subdomain.                                           |
 
 #### Controller Action Decorators
 
@@ -1414,7 +1415,7 @@ export class QuestionController {
 | `@Patch(route: string\|RegExp)`                                | `@Patch("/users/:id") patch()`         | Methods marked with this decorator will register a request made with PATCH HTTP Method to a given route. In action options you can specify if action should response json or regular text response.               | `app.patch("/users/:id", patch)`     |
 | `@Delete(route: string\|RegExp)`                               | `@Delete("/users/:id") delete()`       | Methods marked with this decorator will register a request made with DELETE HTTP Method to a given route. In action options you can specify if action should response json or regular text response.              | `app.delete("/users/:id", delete)`   |
 | `@Head(route: string\|RegExp)`                                 | `@Head("/users/:id") head()`           | Methods marked with this decorator will register a request made with HEAD HTTP Method to a given route. In action options you can specify if action should response json or regular text response.                | `app.head("/users/:id", head)`       |
-| `@Method(methodName: string, route: string\|RegExp)`            | `@Method("move", "/users/:id") move()` | Methods marked with this decorator will register a request made with given `methodName` HTTP Method to a given route. In action options you can specify if action should response json or regular text response.  | `app.move("/users/:id", move)`       |
+| `@Method(methodName: string, route: string\|RegExp)`           | `@Method("move", "/users/:id") move()` | Methods marked with this decorator will register a request made with given `methodName` HTTP Method to a given route. In action options you can specify if action should response json or regular text response.  | `app.move("/users/:id", move)`       |
 
 #### Method Parameter Decorators
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "routing-controllers",
   "private": true,
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Create structured, declarative and beautifully organized class-based controllers with heavy decorators usage for Express / Koa using TypeScript.",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -75,6 +75,7 @@
     "koa-multer": "^1.0.1",
     "koa-router": "^7.1.1",
     "koa-session": "^5.0.0",
+    "koa-subdomain": "^2.1.0",
     "koa-views": "^6.0.1",
     "mocha": "^3.0.0",
     "multer": "^1.3.0",

--- a/src/decorator-options/ControllerOptions.ts
+++ b/src/decorator-options/ControllerOptions.ts
@@ -1,0 +1,16 @@
+/**
+ * Controller decorator parameters.
+ */
+export interface ControllerOptions {
+
+    /**
+     * Extra path you can apply as a base route to all controller actions
+     */
+    baseRoute?: string;
+
+    /**
+     * Subdomain for all actions registered in this controller. 
+     */
+    subdomain?: string;
+
+}

--- a/src/decorator/Controller.ts
+++ b/src/decorator/Controller.ts
@@ -1,18 +1,18 @@
+import { ControllerOptions } from "./../decorator-options/ControllerOptions";
 import {getMetadataArgsStorage} from "../index";
 
 /**
  * Defines a class as a controller.
  * Each decorated controller method is served as a controller action.
  * Controller actions are executed when request come.
- *
- * @param baseRoute Extra path you can apply as a base route to all controller actions
  */
-export function Controller(baseRoute?: string): Function {
+export function Controller(options?: ControllerOptions): Function {
     return function (object: Function) {
         getMetadataArgsStorage().controllers.push({
             type: "default",
             target: object,
-            route: baseRoute
+            route: options ? options.baseRoute : undefined,
+            subdomain: options ? options.subdomain : undefined,
         });
     };
 }

--- a/src/decorator/JsonController.ts
+++ b/src/decorator/JsonController.ts
@@ -1,17 +1,17 @@
+import { ControllerOptions } from "./../decorator-options/ControllerOptions";
 import {getMetadataArgsStorage} from "../index";
 
 /**
  * Defines a class as a JSON controller. If JSON controller is used, then all controller actions will return
  * a serialized json data, and its response content-type always will be application/json.
- *
- * @param baseRoute Extra path you can apply as a base route to all controller actions
  */
-export function JsonController(baseRoute?: string) {
+export function JsonController(options?: ControllerOptions) {
     return function (object: Function) {
         getMetadataArgsStorage().controllers.push({
             type: "json",
             target: object,
-            route: baseRoute
+            route: options ? options.baseRoute : undefined,
+            subdomain: options ? options.subdomain : undefined,
         });
     };
 }

--- a/src/metadata/ControllerMetadata.ts
+++ b/src/metadata/ControllerMetadata.ts
@@ -25,6 +25,11 @@ export class ControllerMetadata {
     target: Function;
 
     /**
+     * Subdomain for all actions registered in this controller.
+     */
+    subdomain: string;
+
+    /**
      * Base route for all actions registered in this controller.
      */
     route: string;
@@ -62,6 +67,7 @@ export class ControllerMetadata {
         this.target = args.target;
         this.route = args.route;
         this.type = args.type;
+        this.subdomain = args.subdomain;
     }
 
     // -------------------------------------------------------------------------

--- a/src/metadata/args/ControllerMetadataArgs.ts
+++ b/src/metadata/args/ControllerMetadataArgs.ts
@@ -8,6 +8,11 @@ export interface ControllerMetadataArgs {
      */
     target: Function;
 
+     /**
+     * Subdomain for all actions registered in this controller.
+     */
+    subdomain: string;
+
     /**
      * Base route for all actions registered in this controller.
      */

--- a/test/functional/controller-base-routes.spec.ts
+++ b/test/functional/controller-base-routes.spec.ts
@@ -10,7 +10,7 @@ describe("controller > base routes functionality", () => {
         // reset metadata args storage
         getMetadataArgsStorage().reset();
 
-        @Controller("/posts")
+        @Controller({ baseRoute: "/posts" })
         class PostController {
             @Get("/")
             getAll() {

--- a/test/functional/controller-methods.spec.ts
+++ b/test/functional/controller-methods.spec.ts
@@ -90,7 +90,7 @@ describe("controller methods", () => {
             }
         }
 
-        @JsonController("/return/json")
+        @JsonController({ baseRoute: "/return/json" })
         class ReturnJsonController {
             @Get("/undefined")
             returnUndefined(): undefined {
@@ -102,7 +102,7 @@ describe("controller methods", () => {
             }
         }
 
-        @Controller("/return/normal")
+        @Controller({ baseRoute: "/return/normal" })
         class ReturnNormalController {
             @Get("/undefined")
             returnUndefined(): undefined {
@@ -114,7 +114,7 @@ describe("controller methods", () => {
             }
         }
 
-        @JsonController("/json-controller")
+        @JsonController({ baseRoute: "/json-controller" })
         class ContentTypeController {
             @Get("/text-html")
             @ContentType("text/html")

--- a/test/functional/redirect-decorator.spec.ts
+++ b/test/functional/redirect-decorator.spec.ts
@@ -15,7 +15,7 @@ describe("dynamic redirect", function () {
         // reset metadata args storage
         getMetadataArgsStorage().reset();
 
-        @JsonController("/users")
+        @JsonController({ baseRoute: "/users" })
         class TestController {
 
             @Get("/:id")


### PR DESCRIPTION
It is now possible to declare a controller to a specific subdomain.

```typescript
    import {Controller, Get} from "routing-controllers";

    @Controller({ subdomain "service" })
    export class ServiceController {

        @Get("/")
        get() {
           return "This action is only fired when on subdomain service";
        }
    }

    @Controller({ subdomain "*.service" })
    export class CustomerServiceController {

        @Get("/")
        get() {
           return "This action is only fired when on subdomain *.service";
        }
    }

    @Controller({ baseRoute: "/api", subdomain "*.service" })
    export class CustomerServiceController {

        @Get("/")
        get() {
           return "This action is only fired when on subdomain *.service and route /api";
        }
    }
```
