### PR TITLE
fix: koa render decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "routing-controllers",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3241,6 +3241,12 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
+    },
+    "http2": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
+      "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "routing-controllers",
-  "version": "0.7.8",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gulp-typescript": "^3.1.6",
     "gulpclass": "^0.1.2",
     "handlebars": "^4.0.6",
+    "http2": "^3.3.7",
     "kcors": "^1.3.2",
     "koa": "^2.0.0",
     "koa-bodyparser": "^4.2.0",

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -232,9 +232,7 @@ export class KoaDriver extends BaseDriver {
         } else if (action.renderedTemplate) { // if template is set then render it // TODO: not working in koa
             const renderOptions = result && result instanceof Object ? result : {};
 
-            this.koa.use(async function (ctx: any, next: any) {
-                await ctx.render(action.renderedTemplate, renderOptions);
-            });
+            return options.response.render(action.renderedTemplate, renderOptions);
         }
         else if (result === undefined) { // throw NotFoundError on undefined response
             if (action.undefinedResultCode instanceof Function) {

--- a/test/functional/render-decorator.spec.ts
+++ b/test/functional/render-decorator.spec.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import {Controller} from "../../src/decorator/Controller";
 import {Get} from "../../src/decorator/Get";
 import {Res} from "../../src/decorator/Res";
-import {createExpressServer, createKoaServer, getMetadataArgsStorage} from "../../src/index";
+import {createExpressServer, createKoaServer, getMetadataArgsStorage, useKoaServer} from "../../src/index";
 import {assertRequest} from "./test-utils";
 import {Render} from "../../src/decorator/Render";
 const chakram = require("chakram");
@@ -53,11 +53,13 @@ describe("template rendering", () => {
     after(done => expressApp.close(done));
 
     let koaApp: any;
-    before(done => {
+    before(done => {        
         const path = __dirname + "/../../../../test/resources";
-        const server = createKoaServer();
-        let koaViews = require("koa-views");
-        server.use(koaViews(path, { map: { html: "handlebars" } } ));
+        const Koa = require("koa");
+        const koa: any = new Koa();
+        const koaViews = require("koa-views");
+        koa.use(koaViews(path, { map: { html: "handlebars" } } ));
+        const server = useKoaServer(koa);
         koaApp = server.listen(3002, done);
     });
     after(done => koaApp.close(done));

--- a/test/http2.d.ts
+++ b/test/http2.d.ts
@@ -1,1 +1,4 @@
-declare module 'http';
+declare module "http2" {
+  export type Http2ServerRequest = any
+  export type Http2ServerResponse = any
+}


### PR DESCRIPTION
When `@Render` exec, that will add a new `middleware`.
Just call `render` to return results.