### PR TITLE
Fix incorrect handling of rejected promises from Middleware.use()

### DIFF
--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -328,24 +328,11 @@ export class KoaDriver extends BaseDriver {
         const middlewareFunctions: Function[] = [];
         uses.forEach(use => {
             if (use.middleware.prototype && use.middleware.prototype.use) { // if this is function instance of MiddlewareInterface
-                middlewareFunctions.push((context: any, next: (err?: any) => Promise<any>) => {
+                middlewareFunctions.push(async (context: any, next: (err?: any) => Promise<any>) => {
                     try {
-                        const useResult = (getFromContainer(use.middleware) as KoaMiddlewareInterface).use(context, next);
-                        if (isPromiseLike(useResult)) {
-                            useResult.catch((error: any) => {
-                                this.handleError(error, undefined, {
-                                    request: context.req,
-                                    response: context.res,
-                                    context,
-                                    next
-                                });
-                                return error;
-                            });
-                        }
-
-                        return useResult;
+                        return await (getFromContainer(use.middleware) as KoaMiddlewareInterface).use(context, next);
                     } catch (error) {
-                        this.handleError(error, undefined, {
+                        return await this.handleError(error, undefined, {
                             request: context.request,
                             response: context.response,
                             context,

--- a/test/functional/koa-middlewares.spec.ts
+++ b/test/functional/koa-middlewares.spec.ts
@@ -68,7 +68,7 @@ describe("koa middlewares", () => {
 
         class TestCustomMiddlewareWhichThrows implements KoaMiddlewareInterface {
 
-            use(request: any, response: any, next?: Function): any {
+            use(context: any, next?: Function): any {
                 throw new NotAcceptableError("TestCustomMiddlewareWhichThrows");
             }
 

--- a/test/functional/koa-middlewares.spec.ts
+++ b/test/functional/koa-middlewares.spec.ts
@@ -127,9 +127,9 @@ describe("koa middlewares", () => {
                 return "1234";
             }
 
-            @Get("/customMiddlewareWichThrows")
+            @Get("/customMiddlewareWhichThrows")
             @UseBefore(TestCustomMiddlewareWhichThrows)
-            customMiddlewareWichThrows() {
+            customMiddlewareWhichThrows() {
                 return "1234";
             }
 
@@ -193,7 +193,7 @@ describe("koa middlewares", () => {
 
     it("should handle errors in custom middlewares", () => {
         return chakram
-            .get("http://127.0.0.1:3001/customMiddlewareWichThrows")
+            .get("http://127.0.0.1:3001/customMiddlewareWhichThrows")
             .then((response: any) => {
                 expect(response).to.have.status(406);
             });

--- a/test/functional/koa-middlewares.spec.ts
+++ b/test/functional/koa-middlewares.spec.ts
@@ -74,6 +74,13 @@ describe("koa middlewares", () => {
 
         }
 
+        class TestCustomAsyncMiddlewareWhichThrows implements KoaMiddlewareInterface {
+
+            async use(context: any, next?: Function): Promise<any> {
+                throw new NotAcceptableError("TestCustomAsyncMiddlewareWhichThrows");
+            }
+
+        }
         @Controller()
         class KoaMiddlewareController {
 
@@ -130,6 +137,12 @@ describe("koa middlewares", () => {
             @Get("/customMiddlewareWhichThrows")
             @UseBefore(TestCustomMiddlewareWhichThrows)
             customMiddlewareWhichThrows() {
+                return "1234";
+            }
+
+            @Get("/customAsyncMiddlewareWhichThrows")
+            @UseBefore(TestCustomAsyncMiddlewareWhichThrows)
+            TestCustomAsyncMiddlewareWhichThrows() {
                 return "1234";
             }
 
@@ -199,4 +212,11 @@ describe("koa middlewares", () => {
             });
     });
 
+    it("should handle errors in custom async middlewares", () => {
+        return chakram
+            .get("http://127.0.0.1:3001/customAsyncMiddlewareWhichThrows")
+            .then((response: any) => {
+                expect(response).to.have.status(406);
+            });
+    });
 });


### PR DESCRIPTION
Currently there are a number of issues in `KoaDriver.prototype.prepareMiddlewares()` which don't correctly handle rejected `Promise`s returned from `KoaMiddlewareInterface`-style classes.

This means a user can't make use of error handling when using an `async` function for `KoaMiddlewareInterface.use()` implementations. Presently, any `throw` in an `async` middleware function is not handled (node logs an "uncaught Promise rejection" error), and the route simply returns the default 404 status.

The simplest way to fix this was to make the `KoaDriver` middleware wrapper function into an `async`, and `await` the completion of the `middleware.use()` (which works for all use cases of `KoaMiddlewareInterface.use()` - ie. `async`, and non-`async in both `Promise` and non-`Promise` returning forms.
