### PR TITLE
Add support for wildcard "all" routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ There are set of prepared errors you can use:
 * UnauthorizedError
 
 
-You can also create and use your own errors by extending `HttpError` class.  
+You can also create and use your own errors by extending `HttpError` class.
 To define the data returned to the client, you could define a toJSON method in your error.
 
 ```typescript
@@ -755,7 +755,7 @@ class DbError extends HttpError {
         }
     }
 }
-``` 
+```
 
 #### Enable CORS
 
@@ -796,7 +796,7 @@ app.listen(3000);
 
 #### Default settings
 
-You can override default status code in routing-controllers options. 
+You can override default status code in routing-controllers options.
 
 ```typescript
 import "reflect-metadata";
@@ -809,9 +809,9 @@ const app = createExpressServer({
         //with this option, null will return 404 by default
         nullResultCode: 404,
 
-        //with this option, void or Promise<void> will return 204 by default 
+        //with this option, void or Promise<void> will return 204 by default
         undefinedResultCode: 204,
-        
+
         paramOptions: {
             //with this option, argument will be required by default
             required: true
@@ -1486,7 +1486,8 @@ export class QuestionController {
 | `@Patch(route: string\|RegExp)`                                | `@Patch("/users/:id") patch()`         | Methods marked with this decorator will register a request made with PATCH HTTP Method to a given route. In action options you can specify if action should response json or regular text response.               | `app.patch("/users/:id", patch)`     |
 | `@Delete(route: string\|RegExp)`                               | `@Delete("/users/:id") delete()`       | Methods marked with this decorator will register a request made with DELETE HTTP Method to a given route. In action options you can specify if action should response json or regular text response.              | `app.delete("/users/:id", delete)`   |
 | `@Head(route: string\|RegExp)`                                 | `@Head("/users/:id") head()`           | Methods marked with this decorator will register a request made with HEAD HTTP Method to a given route. In action options you can specify if action should response json or regular text response.                | `app.head("/users/:id", head)`       |
-| `@Method(methodName: string, route: string\|RegExp)`            | `@Method("move", "/users/:id") move()` | Methods marked with this decorator will register a request made with given `methodName` HTTP Method to a given route. In action options you can specify if action should response json or regular text response.  | `app.move("/users/:id", move)`       |
+| `@All(route: string\|RegExp)`                                  | `@All("/users/me") rewrite()`          | Methods marked with this decorator will register a request made with any HTTP Method to a given route. In action options you can specify if action should response json or regular text response.                 | `app.all("/users/me", rewrite)`      |
+| `@Method(methodName: string, route: string\|RegExp)`           | `@Method("move", "/users/:id") move()` | Methods marked with this decorator will register a request made with given `methodName` HTTP Method to a given route. In action options you can specify if action should response json or regular text response.  | `app.move("/users/:id", move)`       |
 
 #### Method Parameter Decorators
 

--- a/src/decorator/All.ts
+++ b/src/decorator/All.ts
@@ -1,0 +1,28 @@
+import {getMetadataArgsStorage} from "../index";
+
+/**
+ * Registers an action to be executed when a request comes on a given route.
+ * Must be applied on a controller action.
+ */
+export function All(route?: RegExp): Function;
+
+/**
+ * Registers an action to be executed when a request comes on a given route.
+ * Must be applied on a controller action.
+ */
+export function All(route?: string): Function;
+
+/**
+ * Registers an action to be executed when a request comes on a given route.
+ * Must be applied on a controller action.
+ */
+export function All(route?: string|RegExp): Function {
+    return function (object: Object, methodName: string) {
+        getMetadataArgsStorage().actions.push({
+            type: "all",
+            target: object.constructor,
+            method: methodName,
+            route: route
+        });
+    };
+}

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -165,7 +165,7 @@ export class ExpressDriver extends BaseDriver {
             // This causes a double action execution on our side, which results in an unhandled rejection,
             // saying: "Can't set headers after they are sent".
             // The following line skips action processing when the request method does not match the action method.
-            if (request.method.toLowerCase() !== actionMetadata.type)
+            if (actionMetadata.type !== "all" && request.method.toLowerCase() !== actionMetadata.type)
                 return next();
 
             return executeCallback({request, response, next});
@@ -207,7 +207,7 @@ export class ExpressDriver extends BaseDriver {
 
             case "session-param":
                 return request.session[param.name];
-            
+
             case "session":
                 return request.session;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {importClassesFromDirectories} from "./util/importClassesFromDirectories"
 
 export * from "./container";
 
+export * from "./decorator/All";
 export * from "./decorator/Authorized";
 export * from "./decorator/Body";
 export * from "./decorator/BodyParam";

--- a/src/metadata/types/ActionType.ts
+++ b/src/metadata/types/ActionType.ts
@@ -1,7 +1,8 @@
 /**
  * Controller action type.
  */
-export type ActionType = "checkout"
+export type ActionType = "all"
+    |"checkout"
     |"connect"
     |"copy"
     |"delete"

--- a/test/functional/controller-methods.spec.ts
+++ b/test/functional/controller-methods.spec.ts
@@ -7,6 +7,7 @@ import {Head} from "../../src/decorator/Head";
 import {Delete} from "../../src/decorator/Delete";
 import {Patch} from "../../src/decorator/Patch";
 import {Put} from "../../src/decorator/Put";
+import {All} from "../../src/decorator/All";
 import {ContentType} from "../../src/decorator/ContentType";
 import {JsonController} from "../../src/decorator/JsonController";
 import {UnauthorizedError} from "../../src/http-error/UnauthorizedError";
@@ -51,6 +52,10 @@ describe("controller methods", () => {
             @Head("/users")
             head() {
                 return "<html><body>Removing user</body></html>";
+            }
+            @All("/users/me")
+            all() {
+                return "<html><body>Current user</body></html>";
             }
             @Method("post", "/categories")
             postCategories() {
@@ -194,6 +199,19 @@ describe("controller methods", () => {
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
             expect(response.body).to.be.undefined;
         });
+    });
+
+    describe("all respond with proper status code, headers and body content", () => {
+        const callback = (response: any) => {
+            expect(response).to.have.status(200);
+            expect(response).to.have.header("content-type", "text/html; charset=utf-8");
+            expect(response.body).to.be.equal("<html><body>Current user</body></html>");
+        };
+
+        assertRequest([3001, 3002], "get", "users/me", callback);
+        assertRequest([3001, 3002], "put", "users/me", callback);
+        assertRequest([3001, 3002], "patch", "users/me", callback);
+        assertRequest([3001, 3002], "delete", "users/me", callback);
     });
 
     describe("custom method (post) respond with proper status code, headers and body content", () => {


### PR DESCRIPTION
I added support for routes which match all HTTP methods.

A change to the action type vs. request method check in `routeHandler` in the Express driver was required. However, being unfamiliar with the project source I'm not entirely sure this is the only location where such a change is required.