### PR TITLE
chore: add another example for using the response directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ export class UserController {
     @Get("/posts")
     getAllPosts(@Req() request: any, @Res() response: any) {
         // some response functions don't return the response object,
-        // so you need to return it explicitly
+        // so it needs to be returned explicitly
         response.redirect("/users");
 
         return response;

--- a/README.md
+++ b/README.md
@@ -262,8 +262,17 @@ import {Controller, Req, Res, Get} from "routing-controllers";
 export class UserController {
 
     @Get("/users")
-    getAll(@Req() request: any, @Res() response: any) {
+    getAllUsers(@Req() request: any, @Res() response: any) {
         return response.send("Hello response!");
+    }
+
+    @Get("/posts")
+    getAllPosts(@Req() request: any, @Res() response: any) {
+        // some response functions don't return the response object,
+        // so you need to return it explicitly
+        response.redirect("/users");
+
+        return response;
     }
 
 }


### PR DESCRIPTION
Some response functions don't actually return the response object, which
is why it needs to be returned directly.

This took me some time to figure out, so I added an example.