### PR TITLE
feat: load TSX files in `importClassesFormDirectories`

### DIFF
--- a/src/util/importClassesFromDirectories.ts
+++ b/src/util/importClassesFromDirectories.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 /**
  * Loads all exported classes from the given directory.
  */
-export function importClassesFromDirectories(directories: string[], formats = ['.js', '.ts']): Function[] {
+export function importClassesFromDirectories(directories: string[], formats = ['.js', '.ts', '.tsx']): Function[] {
   const loadFileClasses = function (exported: any, allLoaded: Function[]) {
     if (exported instanceof Function) {
       allLoaded.push(exported);


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

Right now you can not use TSX files to define routes. 

We are using React with SSR (only some routes) but the `.tsx` are not loaded by `importClassesFormDirectories` because supporting files are: `.ts` & `.js`

Example:

```javascript
import { Controller, Get, Render } from 'routing-controllers';
import { renderToString } from 'react-dom/server';
import React from 'react';

const Hello = () => <p>Hi!</p>

@Controller()
export class HomeController {
    constructor(private getBanners: GetBanners) {}

    @Get(`/`)
    @Render('home.njk')
    getHome(): void {
       // Render React Component
        const content = renderToString(<Hello />);
        
        return { metadata: { title: 'Home' }, content };
    }
}
```

That route will never appear (return 404)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

