### PR TITLE
feat: add cast array to expected array query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,28 @@ getUsers(@QueryParam("limit") limit: number) {
 }
 ```
 
+You can use `isArray` option to get a query param array. This will cast the query param :
+
+```typescript
+@Get("/users/by-multiple-ids")
+getUsers(@QueryParam("ids", { isArray: true}) ids: string[]) {
+}
+```
+
+`GET /users/by-multiple-ids?ids=a` → `ids = ['a']`
+`GET /users/by-multiple-ids?ids=a&ids=b` → `ids = ['a', 'b']`
+
+You can combine use `isArray` option with `type` option to get a query param array of one type. This will cast the query param :
+
+```typescript
+@Get("/users/by-multiple-ids")
+getUsers(@QueryParam("ids", { isArray: true, type: Number}) ids: number[]) {
+}
+```
+
+`GET /users/by-multiple-ids?ids=1` → `ids = [1]`
+`GET /users/by-multiple-ids?ids=1&ids=3.5` → `ids = [1, 3.5]`
+
 If you want to inject all query parameters use `@QueryParams()` decorator.
 The bigest benefit of this approach is that you can perform validation of the params.
 
@@ -402,12 +424,17 @@ class GetUsersQuery {
     @IsBoolean()
     isActive: boolean;
 
+    @IsArray()
+    @IsNumber(undefined, { each: true })
+    @Type(() => Number)
+    ids: number[];
 }
 
 @Get("/users")
 getUsers(@QueryParams() query: GetUsersQuery) {
     // here you can access query.role, query.limit
     // and others valid query parameters
+    // query.ids will be an array, of numbers, even with one element
 }
 ```
 
@@ -1535,7 +1562,7 @@ export class QuestionController {
 
 | Signature                                                        | Example                                           | Description                                                                                                                                 |
 | ---------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@Authorized(roles?: string\|string[])`                          | `@Authorized("SUPER_ADMIN")` get()                | Checks if user is authorized and has given roles on a given route. `authorizationChecker` should be defined in routing-controllers options. |  |
+| `@Authorized(roles?: string\|string[])`                          | `@Authorized("SUPER_ADMIN")` get()                | Checks if user is authorized and has given roles on a given route. `authorizationChecker` should be defined in routing-controllers options. |
 | `@CurrentUser(options?: { required?: boolean })`                 | get(@CurrentUser({ required: true }) user: User)  | Injects currently authorized user. `currentUserChecker` should be defined in routing-controllers options.                                   |
 | `@Header(headerName: string, headerValue: string)`               | `@Header("Cache-Control", "private")` get()       | Allows to explicitly set any HTTP header returned in the response.                                                                          |
 | `@ContentType(contentType: string)`                              | `@ContentType("text/csv")` get()                  | Allows to explicitly set HTTP Content-Type returned in the response.                                                                        |

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -130,8 +130,11 @@ export class ActionParameterHandler<T extends BaseDriver> {
         case 'string':
         case 'boolean':
         case 'date':
-          return this.normalizeStringValue(value, param.name, param.targetName);
+          const normalizedValue = this.normalizeStringValue(value, param.name, param.targetName);
+          return param.isArray ? [normalizedValue] : normalizedValue;
       }
+    } else if (Array.isArray(value)) {
+      return value.map(v => this.normalizeStringValue(v, param.name, param.targetName));
     }
 
     // if target type is not primitive, transform and validate it
@@ -188,7 +191,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
    */
   protected parseValue(value: any, paramMetadata: ParamMetadata): any {
     if (typeof value === 'string') {
-      if (paramMetadata.type === 'queries' && paramMetadata.targetName === 'array') {
+      if (['queries', 'query'].includes(paramMetadata.type) && paramMetadata.targetName === 'array') {
         return [value];
       } else {
         try {

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -132,6 +132,8 @@ export class ActionParameterHandler<T extends BaseDriver> {
         case 'date':
           const normalizedValue = this.normalizeStringValue(value, param.name, param.targetName);
           return param.isArray ? [normalizedValue] : normalizedValue;
+        case 'array':
+          return [value];
       }
     } else if (Array.isArray(value)) {
       return value.map(v => this.normalizeStringValue(v, param.name, param.targetName));

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -188,10 +188,14 @@ export class ActionParameterHandler<T extends BaseDriver> {
    */
   protected parseValue(value: any, paramMetadata: ParamMetadata): any {
     if (typeof value === 'string') {
-      try {
-        return JSON.parse(value);
-      } catch (error) {
-        throw new ParameterParseJsonError(paramMetadata.name, value);
+      if (paramMetadata.type === 'queries' && paramMetadata.targetName === 'array') {
+        return [value];
+      } else {
+        try {
+          return JSON.parse(value);
+        } catch (error) {
+          throw new ParameterParseJsonError(paramMetadata.name, value);
+        }
       }
     }
     return value;

--- a/src/decorator-options/ParamOptions.ts
+++ b/src/decorator-options/ParamOptions.ts
@@ -32,4 +32,9 @@ export interface ParamOptions {
    * Explicitly set type which should be used for param to perform transformation.
    */
   type?: any;
+
+  /**
+   * Force value to be cast as an array.
+   */
+  isArray?: boolean;
 }

--- a/src/decorator/QueryParam.ts
+++ b/src/decorator/QueryParam.ts
@@ -18,6 +18,7 @@ export function QueryParam(name: string, options?: ParamOptions): Function {
       classTransform: options ? options.transform : undefined,
       explicitType: options ? options.type : undefined,
       validate: options ? options.validate : undefined,
+      isArray: options?.isArray ?? false,
     });
   };
 }

--- a/src/metadata/ParamMetadata.ts
+++ b/src/metadata/ParamMetadata.ts
@@ -79,6 +79,11 @@ export class ParamMetadata {
   transform: (action: Action, value?: any) => Promise<any> | any;
 
   /**
+   * If true, string values are cast to arrays
+   */
+  isArray?: boolean;
+
+  /**
    * Additional parameter options.
    * For example it can be uploader middleware options or body-parser middleware options.
    */
@@ -113,6 +118,7 @@ export class ParamMetadata {
     this.transform = args.transform;
     this.classTransform = args.classTransform;
     this.validate = args.validate;
+    this.isArray = args.isArray;
 
     if (args.explicitType) {
       this.targetType = args.explicitType;

--- a/src/metadata/args/ParamMetadataArgs.ts
+++ b/src/metadata/args/ParamMetadataArgs.ts
@@ -66,4 +66,9 @@ export interface ParamMetadataArgs {
    * Explicitly set type which should be used for Body to perform transformation.
    */
   explicitType?: any;
+
+  /**
+   * Explicitly tell that the QueryParam is an array to force routing-controller to cast it
+   */
+  isArray?: boolean;
 }

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -29,7 +29,7 @@ import { createExpressServer, getMetadataArgsStorage } from '../../src/index';
 import { SessionMiddleware } from '../fakes/global-options/SessionMiddleware';
 import { axios } from '../utilities/axios';
 import DoneCallback = jest.DoneCallback;
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 
 describe(``, () => {
   let expressServer: HttpServer;
@@ -127,6 +127,11 @@ describe(``, () => {
       @IsNumber(undefined, { each: true })
       @Type(() => Number)
       multipleNumberValues?: number[];
+
+      @IsArray()
+      @IsBoolean({ each: true })
+      @Transform(value => (Array.isArray(value) ? value.map(v => v !== 'false') : value !== 'false'))
+      multipleBooleanValues?: boolean[];
 
       @IsArray()
       @IsDate({ each: true })
@@ -533,7 +538,7 @@ describe(``, () => {
   */
 
   it("@QueryParams should give a proper values from request's query parameters", async () => {
-    expect.assertions(9);
+    expect.assertions(10);
     const response = await axios.get(
       '/photos-params?' +
         'sortBy=name&' +
@@ -544,6 +549,8 @@ describe(``, () => {
         'multipleStringValues=b&' +
         'multipleNumberValues=1&' +
         'multipleNumberValues=2.3&' +
+        'multipleBooleanValues=false&' +
+        'multipleBooleanValues=true&' +
         'multipleDateValues=2017-02-01T00:00:00Z&' +
         'multipleDateValues=2017-03-01T00:00:00Z'
     );
@@ -555,6 +562,7 @@ describe(``, () => {
     expect(queryParams1.showAll).toEqual(true);
     expect(queryParams1.multipleStringValues).toEqual(['a', 'b']);
     expect(queryParams1.multipleNumberValues).toEqual([1, 2.3]);
+    expect(queryParams1.multipleBooleanValues).toEqual([false, true]);
     expect(queryParams1.multipleDateValues).toEqual([
       new Date('2017-02-01T00:00:00Z'),
       new Date('2017-03-01T00:00:00Z'),
@@ -562,7 +570,7 @@ describe(``, () => {
   });
 
   it("@QueryParams should give a proper values from request's query parameters and one multiple value", async () => {
-    expect.assertions(9);
+    expect.assertions(10);
     const response = await axios.get(
       '/photos-params?' +
         'sortBy=name&' +
@@ -571,6 +579,7 @@ describe(``, () => {
         'showAll&' +
         'multipleStringValues=a&' +
         'multipleNumberValues=1&' +
+        'multipleBooleanValues=true&' +
         'multipleDateValues=2017-02-01T01:00:00Z'
     );
     expect(response.status).toEqual(HttpStatusCodes.OK);
@@ -581,11 +590,12 @@ describe(``, () => {
     expect(queryParams1.showAll).toEqual(true);
     expect(queryParams1.multipleStringValues).toEqual(['a']);
     expect(queryParams1.multipleNumberValues).toEqual([1]);
+    expect(queryParams1.multipleBooleanValues).toEqual([true]);
     expect(queryParams1.multipleDateValues).toEqual([new Date('2017-02-01T01:00:00Z')]);
   });
 
   it("@QueryParams should give a proper values from request's query parameters with nested json", async () => {
-    expect.assertions(12);
+    expect.assertions(13);
     const response = await axios.get(
       '/photos-params?' +
         'sortBy=name&' +
@@ -597,6 +607,8 @@ describe(``, () => {
         'multipleStringValues=b&' +
         'multipleNumberValues=1&' +
         'multipleNumberValues=2.3&' +
+        'multipleBooleanValues=false&' +
+        'multipleBooleanValues=true&' +
         'multipleDateValues=2017-02-01T00:00:00Z'
     );
     expect(response.status).toEqual(HttpStatusCodes.OK);
@@ -610,6 +622,7 @@ describe(``, () => {
     expect(queryParams1.myObject.isFive).toEqual(true);
     expect(queryParams1.multipleStringValues).toEqual(['a', 'b']);
     expect(queryParams1.multipleNumberValues).toEqual([1, 2.3]);
+    expect(queryParams1.multipleBooleanValues).toEqual([false, true]);
     expect(queryParams1.multipleDateValues).toEqual([new Date('2017-02-01T00:00:00Z')]);
   });
 

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -38,6 +38,7 @@ describe(``, () => {
   let queryParamSortBy: string | undefined,
     queryParamCount: string | undefined,
     queryParamLimit: number | undefined,
+    queryParamValues: any[] | undefined,
     queryParamShowAll: boolean | undefined,
     queryParamFilter: Record<string, any> | undefined;
   let queryParams1: { [key: string]: any } | undefined,
@@ -237,6 +238,30 @@ describe(``, () => {
       getPhotosWithIdRequired(@QueryParam('limit', { required: true }) limit: number): string {
         queryParamLimit = limit;
         return `<html><body>${limit}</body></html>`;
+      }
+
+      @Get('/photos-query-param-string-array')
+      getPhotosWithMultipleStringValuesRequired(
+        @QueryParam('multipleStringValues', { required: true }) values: string[]
+      ): string {
+        queryParamValues = values;
+        return `<html><body>${values}</body></html>`;
+      }
+
+      @Get('/photos-query-param-number-array')
+      getPhotosWithMultipleNumberValuesRequired(
+        @QueryParam('multipleNumberValues', { required: true, type: Number, isArray: true }) values: number[]
+      ): string {
+        queryParamValues = values;
+        return `<html><body>${values}</body></html>`;
+      }
+
+      @Get('/photos-query-param-date-array')
+      getPhotosWithMultipleDateValuesRequired(
+        @QueryParam('multipleDateValues', { required: true, type: Date, isArray: true }) values: Date[]
+      ): string {
+        queryParamValues = values;
+        return `<html><body>${values}</body></html>`;
       }
 
       @Get('/photos-with-json')
@@ -619,6 +644,60 @@ describe(``, () => {
     expect(queryParamCount).toEqual('2');
     expect(queryParamLimit).toEqual(10);
     expect(queryParamShowAll).toEqual(true);
+  });
+
+  it('@QueryParam should give an array of string with only one query parameter', async () => {
+    expect.assertions(3);
+    const response = await axios.get('/photos-query-param-string-array?multipleStringValues=a');
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual(['a']);
+  });
+
+  it('@QueryParam should give an array of string with multiple query parameters', async () => {
+    expect.assertions(3);
+    const response = await axios.get(
+      '/photos-query-param-string-array?multipleStringValues=a&multipleStringValues=b&multipleStringValues=b'
+    );
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual(['a', 'b', 'b']);
+  });
+
+  it('@QueryParam should give an array of number with only one query parameter', async () => {
+    expect.assertions(3);
+    const response = await axios.get('/photos-query-param-number-array?multipleNumberValues=1');
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual([1]);
+  });
+
+  it('@QueryParam should give an array of number with multiple query parameters', async () => {
+    expect.assertions(3);
+    const response = await axios.get(
+      '/photos-query-param-number-array?multipleNumberValues=1&multipleNumberValues=2&multipleNumberValues=2'
+    );
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual([1, 2, 2]);
+  });
+
+  it('@QueryParam should give an array of date with only one query parameter', async () => {
+    expect.assertions(3);
+    const response = await axios.get('/photos-query-param-date-array?multipleDateValues=2021-01-01');
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual([new Date('2021-01-01')]);
+  });
+
+  it('@QueryParam should give an array of date with multiple query parameters', async () => {
+    expect.assertions(3);
+    const response = await axios.get(
+      '/photos-query-param-date-array?multipleDateValues=2021-01-01&multipleDateValues=2020-01-01&multipleDateValues=2021-05-01'
+    );
+    expect(response.status).toEqual(HttpStatusCodes.OK);
+    expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+    expect(queryParamValues).toEqual([new Date('2021-01-01'), new Date('2020-01-01'), new Date('2021-05-01')]);
   });
 
   it('@QueryParam when required params must be provided and they should not be empty', async () => {


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors → tests pass

### Fixes
Fixes #389, Fixes #320, Fixes #123

The idea is to parse query parameters as it is used to be. I added some exemple in the README, and in the tests :

You can use `isArray` option to get a query param array. This will cast the query param :

```typescript
@Get("/users/by-multiple-ids")
getUsers(@QueryParam("ids", { isArray: true}) ids: string[]) {
}
```

`GET /users/by-multiple-ids?ids=a` → `ids = ['a']`
`GET /users/by-multiple-ids?ids=a&ids=b` → `ids = ['a', 'b']`

You can combine use `isArray` option with `type` option to get a query param array of one type. This will cast the query param :

```typescript
@Get("/users/by-multiple-ids")
getUsers(@QueryParam("ids", { isArray: true, type: Number}) ids: number[]) {
}
```

`GET /users/by-multiple-ids?ids=1` → `ids = [1]`
`GET /users/by-multiple-ids?ids=1&ids=3.5` → `ids = [1, 3.5]`

For QueryParams : 

```typescript
enum Roles {
    Admin = "admin",
    User = "user",
    Guest = "guest",
}

class GetUsersQuery {

    @IsPositive()
    limit: number;

    @IsAlpha()
    city: string;

    @IsEnum(Roles)
    role: Roles;

    @IsBoolean()
    isActive: boolean;

    @IsArray()
    @IsNumber(undefined, { each: true })
    @Type(() => Number)
    ids: number[];
}

@Get("/users")
getUsers(@QueryParams() query: GetUsersQuery) {
    // here you can access query.role, query.limit
    // and others valid query parameters
    // query.ids will be an array, of numbers, even with one element
}



