### PR TITLE
fix: execute authMiddlewares before any middlewares

### DIFF
--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -183,7 +183,15 @@ export class ExpressDriver extends BaseDriver {
 
     // finally register action in express
     this.express[actionMetadata.type.toLowerCase()](
-      ...[route, routeGuard, ...authMiddlewares, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
+      ...[
+        route,
+        routeGuard,
+        ...authMiddlewares,
+        ...beforeMiddlewares,
+        ...defaultMiddlewares,
+        routeHandler,
+        ...afterMiddlewares,
+      ]
     );
   }
 

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -98,6 +98,7 @@ export class ExpressDriver extends BaseDriver {
   registerAction(actionMetadata: ActionMetadata, executeCallback: (options: Action) => any): void {
     // middlewares required for this action
     const defaultMiddlewares: any[] = [];
+    const authMiddlewares: any[] = [];
 
     if (actionMetadata.isBodyUsed) {
       if (actionMetadata.isJsonTyped) {
@@ -108,7 +109,7 @@ export class ExpressDriver extends BaseDriver {
     }
 
     if (actionMetadata.isAuthorizedUsed) {
-      defaultMiddlewares.push((request: any, response: any, next: Function) => {
+      authMiddlewares.push((request: any, response: any, next: Function) => {
         if (!this.authorizationChecker) throw new AuthorizationCheckerNotDefinedError();
 
         const action: Action = { request, response, next };
@@ -182,7 +183,7 @@ export class ExpressDriver extends BaseDriver {
 
     // finally register action in express
     this.express[actionMetadata.type.toLowerCase()](
-      ...[route, routeGuard, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
+      ...[route, routeGuard, ...authMiddlewares, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
     );
   }
 

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -152,7 +152,15 @@ export class KoaDriver extends BaseDriver {
 
     // finally register action in koa
     this.router[actionMetadata.type.toLowerCase()](
-      ...[route, routeGuard, ...authMiddlewares, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
+      ...[
+        route,
+        routeGuard,
+        ...authMiddlewares,
+        ...beforeMiddlewares,
+        ...defaultMiddlewares,
+        routeHandler,
+        ...afterMiddlewares,
+      ]
     );
   }
 

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -72,9 +72,10 @@ export class KoaDriver extends BaseDriver {
   registerAction(actionMetadata: ActionMetadata, executeCallback: (options: Action) => any): void {
     // middlewares required for this action
     const defaultMiddlewares: any[] = [];
+    const authMiddlewares: any[] = [];
 
     if (actionMetadata.isAuthorizedUsed) {
-      defaultMiddlewares.push((context: any, next: Function) => {
+      authMiddlewares.push((context: any, next: Function) => {
         if (!this.authorizationChecker) throw new AuthorizationCheckerNotDefinedError();
 
         const action: Action = { request: context.request, response: context.response, context, next };
@@ -151,7 +152,7 @@ export class KoaDriver extends BaseDriver {
 
     // finally register action in koa
     this.router[actionMetadata.type.toLowerCase()](
-      ...[route, routeGuard, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
+      ...[route, routeGuard, ...authMiddlewares, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
     );
   }
 


### PR DESCRIPTION
## Description

The authorization checker is executed after the middlewares (beforeMiddlewares). This not really make sens when you want to limit access to resources.

**Actual behavior**
![Screen Shot 2021-04-05 at 5 35 32 PM](https://user-images.githubusercontent.com/1795343/113630329-aa540c00-9635-11eb-90d5-c238ba7e864b.png)

**Expected behavior**

![Screen Shot 2021-04-05 at 5 37 08 PM](https://user-images.githubusercontent.com/1795343/113630262-8db7d400-9635-11eb-941b-ba2a19bc446e.png)

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes

fixes #697
