### PR TITLE
feat: Impossible to use UUID as param for object construction

### DIFF
--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -10,7 +10,6 @@ import { AuthorizationRequiredError } from './error/AuthorizationRequiredError';
 import { CurrentUserCheckerNotDefinedError } from './error/CurrentUserCheckerNotDefinedError';
 import { isPromiseLike } from './util/isPromiseLike';
 import { InvalidParamError } from './error/ParamNormalizationError';
-import {ParamType} from "./metadata/types/ParamType";
 
 /**
  * Handles action parameter.
@@ -97,7 +96,9 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
+    const isNormalisationNeeded =
+      typeof value === 'object' &&
+      ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
     const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
 

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -10,6 +10,7 @@ import { AuthorizationRequiredError } from './error/AuthorizationRequiredError';
 import { CurrentUserCheckerNotDefinedError } from './error/CurrentUserCheckerNotDefinedError';
 import { isPromiseLike } from './util/isPromiseLike';
 import { InvalidParamError } from './error/ParamNormalizationError';
+import {ParamType} from "./metadata/types/ParamType";
 
 /**
  * Handles action parameter.
@@ -96,11 +97,12 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    // if param value is an object and param type match, normalize its string properties
-    if (
-      typeof value === 'object' &&
-      ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type)
-    ) {
+    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
+    const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
+    const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
+
+      // if param value is an object and param type match, normalize its string properties
+    if (isNormalisationNeeded) {
       await Promise.all(
         Object.keys(value).map(async key => {
           const keyValue = value[key];
@@ -123,6 +125,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
         })
       );
     }
+
     // if value is a string, normalize it to demanded type
     else if (typeof value === 'string') {
       switch (param.targetName) {
@@ -134,8 +137,12 @@ export class ActionParameterHandler<T extends BaseDriver> {
       }
     }
 
+      console.log(value);
+      console.log(param.targetName);
+
     // if target type is not primitive, transform and validate it
-    if (['number', 'string', 'boolean'].indexOf(param.targetName) === -1 && (param.parse || param.isTargetObject)) {
+
+    if (!isTargetPrimitive && isTransformationNeeded) {
       value = this.parseValue(value, param);
       value = this.transformValue(value, param);
       value = await this.validateValue(value, param);

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -101,7 +101,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
     const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
 
-      // if param value is an object and param type match, normalize its string properties
+    // if param value is an object and param type match, normalize its string properties
     if (isNormalisationNeeded) {
       await Promise.all(
         Object.keys(value).map(async key => {
@@ -137,11 +137,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
       }
     }
 
-      console.log(value);
-      console.log(param.targetName);
-
     // if target type is not primitive, transform and validate it
-
     if (!isTargetPrimitive && isTransformationNeeded) {
       value = this.parseValue(value, param);
       value = this.transformValue(value, param);

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -18,7 +18,6 @@ describe('ActionParameterHandler', () => {
       },
       response: {},
     };
-
     const controllerMetadataArgs: ControllerMetadataArgs = {
       target: function () {},
       route: '',
@@ -35,7 +34,6 @@ describe('ActionParameterHandler', () => {
       appendParams: undefined,
     };
     const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
-
     const param: ParamMetadata = {
       targetName: 'product',
       isTargetObject: true,

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -7,9 +7,6 @@ const expect = require('chakram').expect;
 
 describe('ActionParameterHandler', () => {
   it('handle method keeps string(UUID) parameters untouched', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-
     const action = {
       request: {
         params: {
@@ -55,6 +52,8 @@ describe('ActionParameterHandler', () => {
       targetType: function () {},
     };
 
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
     const processedValue = await actionParameterHandler.handle(action, param);
 
     expect(processedValue).to.be.eq(action.request.params.id);

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,0 +1,93 @@
+import {ActionParameterHandler} from "../src/ActionParameterHandler";
+import {
+  Action,
+  ActionMetadata,
+  ControllerMetadata,
+  createExpressServer,
+  ParamMetadata,
+  RoutingControllersOptions
+} from "../src";
+import {IncomingMessage} from "http";
+import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
+import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
+
+const Socket = require("net").Socket;
+
+const expect = require("chakram").expect;
+
+describe("ActionParameterHandler", () => {
+
+  it("handle", () => {
+
+    const driver = createExpressServer();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+
+    // console.log(actionParameterHandler);
+    const socket = new Socket();
+    const action = {
+      request: new IncomingMessage(socket),
+      response: new IncomingMessage(socket)
+    };
+    action.request.headers = {
+      host: "0.0.0.0:3000",
+      connection: "keep-alive",
+      "cache-control": "max-age=0",
+      "upgrade-insecure-requests": "1",
+      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36",
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "accept-encoding": "gzip, deflate",
+      "accept-language": "en,en-US;q=0.9,da;q=0.8,de;q=0.7,es;q=0.6,fr;q=0.5,ru;q=0.4,nl;q=0.3,sv;q=0.2,sl;q=0.1,pt;q=0.1,ro;q=0.1,nb;q=0.1,it;q=0.1,uk;q=0.1,gl;q=0.1,la;q=0.1"
+    };
+    action.request.url = "/api/products/04879b32-c329-48d7-a652-818794b684f1";
+    const controllerMetadataArgs: ControllerMetadataArgs = {
+      target: function () {
+
+      },
+      route: "",
+      type: "json",
+      options: {},
+    };
+    const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
+    const args: ActionMetadataArgs = {
+      route: "",
+      method: "getProduct",
+      options: {},
+      target: function () {
+
+      },
+      type: "get",
+      appendParams: undefined,
+    };
+    const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
+
+    const param: ParamMetadata = {
+      targetName: "product",
+      isTargetObject: true,
+      actionMetadata,
+      target: () => {
+      },
+      method: "getProduct",
+      object: "getProduct",
+      extraOptions: undefined,
+      index: 0,
+      type: "param",
+      name: "id",
+      parse: undefined,
+      required: undefined,
+      transform: function () {
+
+      },
+      classTransform: undefined,
+      validate: undefined,
+      targetType: function () {
+
+      },
+    };
+
+    console.log(param);
+
+    actionParameterHandler.handle(action, param);
+
+  });
+})
+;

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,47 +1,31 @@
 import {ActionParameterHandler} from "../src/ActionParameterHandler";
 import {
-  Action,
-  ActionMetadata, BaseDriver,
+  ActionMetadata,
   ControllerMetadata,
-  createExpressServer, ExpressDriver,
+  ExpressDriver,
   ParamMetadata,
-  RoutingControllersOptions
 } from "../src";
-import {IncomingMessage} from "http";
 import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
 import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
-
-const Socket = require("net").Socket;
 
 const expect = require("chakram").expect;
 
 describe("ActionParameterHandler", () => {
 
-  it("handle", () => {
-
+  it("handle", async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
 
-    // console.log(actionParameterHandler);
-    const socket = new Socket();
     const action = {
-      request: new IncomingMessage(socket),
-      response: new IncomingMessage(socket)
+      request: {
+        params: {
+          id: "0b5ec98f-e26d-4414-b798-dcd35a5ef859"
+        },
+      },
+      response: {}
     };
-    action.request.headers = {
-      host: "0.0.0.0:3000",
-      connection: "keep-alive",
-      "cache-control": "max-age=0",
-      "upgrade-insecure-requests": "1",
-      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36",
-      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-      "accept-encoding": "gzip, deflate",
-      "accept-language": "en,en-US;q=0.9,da;q=0.8,de;q=0.7,es;q=0.6,fr;q=0.5,ru;q=0.4,nl;q=0.3,sv;q=0.2,sl;q=0.1,pt;q=0.1,ro;q=0.1,nb;q=0.1,it;q=0.1,uk;q=0.1,gl;q=0.1,la;q=0.1"
-    };
-    action.request.url = "/api/products/04879b32-c329-48d7-a652-818794b684f1";
     const controllerMetadataArgs: ControllerMetadataArgs = {
       target: function () {
-
       },
       route: "",
       type: "json",
@@ -73,9 +57,9 @@ describe("ActionParameterHandler", () => {
       type: "param",
       name: "id",
       parse: undefined,
-      required: undefined,
-      transform: function () {
-
+      required: false,
+      transform: function (action, value) {
+        return value;
       },
       classTransform: undefined,
       validate: undefined,
@@ -84,10 +68,9 @@ describe("ActionParameterHandler", () => {
       },
     };
 
-    console.log(param);
+    const processedValue = await actionParameterHandler.handle(action, param);
 
-    actionParameterHandler.handle(action, param);
-
+    expect(processedValue).to.be.eq(action.request.params.id);
   });
-})
-;
+
+});

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -17,7 +17,7 @@ describe('ActionParameterHandler', () => {
     };
     const controllerMetadataArgs: ControllerMetadataArgs = {
       target: function () {},
-      route: '',
+      route: '/',
       type: 'json',
       options: {},
     };

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,9 +1,9 @@
 import {ActionParameterHandler} from "../src/ActionParameterHandler";
 import {
   Action,
-  ActionMetadata,
+  ActionMetadata, BaseDriver,
   ControllerMetadata,
-  createExpressServer,
+  createExpressServer, ExpressDriver,
   ParamMetadata,
   RoutingControllersOptions
 } from "../src";
@@ -19,7 +19,7 @@ describe("ActionParameterHandler", () => {
 
   it("handle", () => {
 
-    const driver = createExpressServer();
+    const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
 
     // console.log(actionParameterHandler);

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -12,7 +12,7 @@ const expect = require("chakram").expect;
 
 describe("ActionParameterHandler", () => {
 
-  it("handle", async () => {
+  it("handle method keeps string(UUID) parameters untouched", async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
 
@@ -24,6 +24,7 @@ describe("ActionParameterHandler", () => {
       },
       response: {}
     };
+
     const controllerMetadataArgs: ControllerMetadataArgs = {
       target: function () {
       },

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,62 +1,52 @@
-import {ActionParameterHandler} from "../src/ActionParameterHandler";
-import {
-  ActionMetadata,
-  ControllerMetadata,
-  ExpressDriver,
-  ParamMetadata,
-} from "../src";
-import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
-import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
+import { ActionParameterHandler } from '../src/ActionParameterHandler';
+import { ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata } from '../src';
+import { ActionMetadataArgs } from '../src/metadata/args/ActionMetadataArgs';
+import { ControllerMetadataArgs } from '../src/metadata/args/ControllerMetadataArgs';
 
-const expect = require("chakram").expect;
+const expect = require('chakram').expect;
 
-describe("ActionParameterHandler", () => {
-
-  it("handle method keeps string(UUID) parameters untouched", async () => {
+describe('ActionParameterHandler', () => {
+  it('handle method keeps string(UUID) parameters untouched', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
 
     const action = {
       request: {
         params: {
-          id: "0b5ec98f-e26d-4414-b798-dcd35a5ef859"
+          id: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
         },
       },
-      response: {}
+      response: {},
     };
 
     const controllerMetadataArgs: ControllerMetadataArgs = {
-      target: function () {
-      },
-      route: "",
-      type: "json",
+      target: function () {},
+      route: '',
+      type: 'json',
       options: {},
     };
     const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
     const args: ActionMetadataArgs = {
-      route: "",
-      method: "getProduct",
+      route: '',
+      method: 'getProduct',
       options: {},
-      target: function () {
-
-      },
-      type: "get",
+      target: function () {},
+      type: 'get',
       appendParams: undefined,
     };
     const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
 
     const param: ParamMetadata = {
-      targetName: "product",
+      targetName: 'product',
       isTargetObject: true,
       actionMetadata,
-      target: () => {
-      },
-      method: "getProduct",
-      object: "getProduct",
+      target: () => {},
+      method: 'getProduct',
+      object: 'getProduct',
       extraOptions: undefined,
       index: 0,
-      type: "param",
-      name: "id",
+      type: 'param',
+      name: 'id',
       parse: undefined,
       required: false,
       transform: function (action, value) {
@@ -64,14 +54,11 @@ describe("ActionParameterHandler", () => {
       },
       classTransform: undefined,
       validate: undefined,
-      targetType: function () {
-
-      },
+      targetType: function () {},
     };
 
     const processedValue = await actionParameterHandler.handle(action, param);
 
     expect(processedValue).to.be.eq(action.request.params.id);
   });
-
 });


### PR DESCRIPTION
## Description
The usage of UUID instead of id in routes like http://0.0.0.0:3000/api/products/04879b32-c329-48d7-a652-818794b684f1
Is trying to build JSON object while returning a raw parameter(UUID) provided.

Ref: https://github.com/typestack/routing-controllers/issues/703

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [s] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
The conditions the inside `normalizeParamValue` now excluding "param" type, keeping UUID strings untouched
