### PR TITLE
feat: Impossible to use UUID as param for object construction #706

### DIFF
--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -10,7 +10,6 @@ import { AuthorizationRequiredError } from './error/AuthorizationRequiredError';
 import { CurrentUserCheckerNotDefinedError } from './error/CurrentUserCheckerNotDefinedError';
 import { isPromiseLike } from './util/isPromiseLike';
 import { InvalidParamError } from './error/ParamNormalizationError';
-import {ParamType} from "./metadata/types/ParamType";
 
 /**
  * Handles action parameter.
@@ -97,7 +96,9 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
+    const isNormalisationNeeded =
+      typeof value === 'object' &&
+      ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
     const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
 

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -96,10 +96,8 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    const isNormalisationNeeded =
-      typeof value === 'object' &&
-      ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
-    const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
+    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].includes(param.type);
+    const isTargetPrimitive = ['number', 'string', 'boolean'].includes(param.targetName);
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
 
     // if param value is an object and param type match, normalize its string properties

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -96,7 +96,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    const isNormalisationNeeded =
+    const isNormalizationNeeded =
       typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].includes(param.type);
     const isTargetPrimitive = ['number', 'string', 'boolean'].includes(param.targetName);
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -10,6 +10,7 @@ import { AuthorizationRequiredError } from './error/AuthorizationRequiredError';
 import { CurrentUserCheckerNotDefinedError } from './error/CurrentUserCheckerNotDefinedError';
 import { isPromiseLike } from './util/isPromiseLike';
 import { InvalidParamError } from './error/ParamNormalizationError';
+import {ParamType} from "./metadata/types/ParamType";
 
 /**
  * Handles action parameter.
@@ -96,11 +97,12 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
+    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type);
+    const isTargetPrimitive = ['number', 'string', 'boolean'].indexOf(param.targetName) > -1;
+    const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
+
     // if param value is an object and param type match, normalize its string properties
-    if (
-      typeof value === 'object' &&
-      ['queries', 'headers', 'params', 'cookies'].some(paramType => paramType === param.type)
-    ) {
+    if (isNormalisationNeeded) {
       await Promise.all(
         Object.keys(value).map(async key => {
           const keyValue = value[key];
@@ -123,6 +125,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
         })
       );
     }
+
     // if value is a string, normalize it to demanded type
     else if (typeof value === 'string') {
       switch (param.targetName) {
@@ -135,7 +138,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
     }
 
     // if target type is not primitive, transform and validate it
-    if (['number', 'string', 'boolean'].indexOf(param.targetName) === -1 && (param.parse || param.isTargetObject)) {
+    if (!isTargetPrimitive && isTransformationNeeded) {
       value = this.parseValue(value, param);
       value = this.transformValue(value, param);
       value = await this.validateValue(value, param);

--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -96,7 +96,8 @@ export class ActionParameterHandler<T extends BaseDriver> {
   protected async normalizeParamValue(value: any, param: ParamMetadata): Promise<any> {
     if (value === null || value === undefined) return value;
 
-    const isNormalisationNeeded = typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].includes(param.type);
+    const isNormalisationNeeded =
+      typeof value === 'object' && ['queries', 'headers', 'params', 'cookies'].includes(param.type);
     const isTargetPrimitive = ['number', 'string', 'boolean'].includes(param.targetName);
     const isTransformationNeeded = (param.parse || param.isTargetObject) && param.type !== 'param';
 

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,0 +1,76 @@
+import {ActionParameterHandler} from "../src/ActionParameterHandler";
+import {
+  ActionMetadata,
+  ControllerMetadata,
+  ExpressDriver,
+  ParamMetadata,
+} from "../src";
+import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
+import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
+
+const expect = require("chakram").expect;
+
+describe("ActionParameterHandler", () => {
+
+  it("handle", async () => {
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+
+    const action = {
+      request: {
+        params: {
+          id: "0b5ec98f-e26d-4414-b798-dcd35a5ef859"
+        },
+      },
+      response: {}
+    };
+    const controllerMetadataArgs: ControllerMetadataArgs = {
+      target: function () {
+      },
+      route: "",
+      type: "json",
+      options: {},
+    };
+    const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
+    const args: ActionMetadataArgs = {
+      route: "",
+      method: "getProduct",
+      options: {},
+      target: function () {
+
+      },
+      type: "get",
+      appendParams: undefined,
+    };
+    const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
+
+    const param: ParamMetadata = {
+      targetName: "product",
+      isTargetObject: true,
+      actionMetadata,
+      target: () => {
+      },
+      method: "getProduct",
+      object: "getProduct",
+      extraOptions: undefined,
+      index: 0,
+      type: "param",
+      name: "id",
+      parse: undefined,
+      required: false,
+      transform: function (action, value) {
+        return value;
+      },
+      classTransform: undefined,
+      validate: undefined,
+      targetType: function () {
+
+      },
+    };
+
+    const processedValue = await actionParameterHandler.handle(action, param);
+
+    expect(processedValue).to.be.eq(action.request.params.id);
+  });
+
+});

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,61 +1,51 @@
-import {ActionParameterHandler} from "../src/ActionParameterHandler";
-import {
-  ActionMetadata,
-  ControllerMetadata,
-  ExpressDriver,
-  ParamMetadata,
-} from "../src";
-import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
-import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
+import { ActionParameterHandler } from '../src/ActionParameterHandler';
+import { ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata } from '../src';
+import { ActionMetadataArgs } from '../src/metadata/args/ActionMetadataArgs';
+import { ControllerMetadataArgs } from '../src/metadata/args/ControllerMetadataArgs';
 
-const expect = require("chakram").expect;
+const expect = require('chakram').expect;
 
-describe("ActionParameterHandler", () => {
-
-  it("handle", async () => {
+describe('ActionParameterHandler', () => {
+  it('handle', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
 
     const action = {
       request: {
         params: {
-          id: "0b5ec98f-e26d-4414-b798-dcd35a5ef859"
+          id: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
         },
       },
-      response: {}
+      response: {},
     };
     const controllerMetadataArgs: ControllerMetadataArgs = {
-      target: function () {
-      },
-      route: "",
-      type: "json",
+      target: function () {},
+      route: '',
+      type: 'json',
       options: {},
     };
     const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
     const args: ActionMetadataArgs = {
-      route: "",
-      method: "getProduct",
+      route: '',
+      method: 'getProduct',
       options: {},
-      target: function () {
-
-      },
-      type: "get",
+      target: function () {},
+      type: 'get',
       appendParams: undefined,
     };
     const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
 
     const param: ParamMetadata = {
-      targetName: "product",
+      targetName: 'product',
       isTargetObject: true,
       actionMetadata,
-      target: () => {
-      },
-      method: "getProduct",
-      object: "getProduct",
+      target: () => {},
+      method: 'getProduct',
+      object: 'getProduct',
       extraOptions: undefined,
       index: 0,
-      type: "param",
-      name: "id",
+      type: 'param',
+      name: 'id',
       parse: undefined,
       required: false,
       transform: function (action, value) {
@@ -63,14 +53,11 @@ describe("ActionParameterHandler", () => {
       },
       classTransform: undefined,
       validate: undefined,
-      targetType: function () {
-
-      },
+      targetType: function () {},
     };
 
     const processedValue = await actionParameterHandler.handle(action, param);
 
     expect(processedValue).to.be.eq(action.request.params.id);
   });
-
 });

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,51 +1,43 @@
-import { ActionParameterHandler } from '../src/ActionParameterHandler';
-import { ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata } from '../src';
-import { ActionMetadataArgs } from '../src/metadata/args/ActionMetadataArgs';
-import { ControllerMetadataArgs } from '../src/metadata/args/ControllerMetadataArgs';
+import {ActionParameterHandler} from "../src/ActionParameterHandler";
+import {ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata} from "../src";
+import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
+import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
 
-const expect = require('chakram').expect;
+const expect = require("chakram").expect;
 
-describe('ActionParameterHandler', () => {
-  it('handle', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-
-    const action = {
-      request: {
-        params: {
-          id: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
-        },
-      },
-      response: {},
-    };
+describe("ActionParameterHandler", () => {
+  const buildParamMetadata = (): ParamMetadata => {
     const controllerMetadataArgs: ControllerMetadataArgs = {
-      target: function () {},
-      route: '',
-      type: 'json',
+      target: function () {
+      },
+      route: "",
+      type: "json",
       options: {},
     };
     const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
     const args: ActionMetadataArgs = {
-      route: '',
-      method: 'getProduct',
+      route: "",
+      method: "getProduct",
       options: {},
-      target: function () {},
-      type: 'get',
+      target: function () {
+      },
+      type: "get",
       appendParams: undefined,
     };
     const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
 
-    const param: ParamMetadata = {
-      targetName: 'product',
+    return {
+      targetName: "product",
       isTargetObject: true,
       actionMetadata,
-      target: () => {},
-      method: 'getProduct',
-      object: 'getProduct',
+      target: () => {
+      },
+      method: "getProduct",
+      object: "getProduct",
       extraOptions: undefined,
       index: 0,
-      type: 'param',
-      name: 'id',
+      type: "param",
+      name: "id",
       parse: undefined,
       required: false,
       transform: function (action, value) {
@@ -53,11 +45,83 @@ describe('ActionParameterHandler', () => {
       },
       classTransform: undefined,
       validate: undefined,
-      targetType: function () {},
+      targetType: function () {
+      },
+    };
+  };
+
+  it("handle - should process string parameters", async () => {
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+    const param = buildParamMetadata();
+
+    const action = {
+      request: {
+        params: {
+          id: "0b5ec98f-e26d-4414-b798-dcd35a5ef859",
+        },
+      },
+      response: {},
     };
 
     const processedValue = await actionParameterHandler.handle(action, param);
 
     expect(processedValue).to.be.eq(action.request.params.id);
   });
+
+  it("handle - should process string parameters, returns empty if a given string is empty", async () => {
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+    const param = buildParamMetadata();
+
+    const action = {
+      request: {
+        params: {
+          id: "",
+        },
+      },
+      response: {},
+    };
+
+    const processedValue = await actionParameterHandler.handle(action, param);
+
+    expect(processedValue).to.be.eq(action.request.params.id);
+  });
+
+  it("handle - should process number parameters", async () => {
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+    const param = buildParamMetadata();
+
+    const action = {
+      request: {
+        params: {
+          id: 10000,
+        },
+      },
+      response: {},
+    };
+
+    const processedValue = await actionParameterHandler.handle(action, param);
+
+    expect(processedValue).to.be.eq(action.request.params.id);
+  });
+
+  it("handle - undefined on empty object provided", async () => {
+    const driver = new ExpressDriver();
+    const actionParameterHandler = new ActionParameterHandler(driver);
+    const param = buildParamMetadata();
+
+    const action = {
+      request: {
+        params: {},
+      },
+      response: {},
+    };
+
+    const processedValue = await actionParameterHandler.handle(action, param);
+
+    expect(processedValue).to.be.eq(undefined);
+  });
+
 });

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -50,120 +50,107 @@ describe('ActionParameterHandler', () => {
       targetType: function () {},
     };
   };
+  const driver = new ExpressDriver();
+  const actionParameterHandler = new ActionParameterHandler(driver);
 
-  it('handle - should process string parameters', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata('uuid');
-
-    const action = {
-      request: {
-        params: {
-          uuid: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
+  describe('positive', () => {
+    it('handle - should process string parameters', async () => {
+      const param = buildParamMetadata('uuid');
+      const action = {
+        request: {
+          params: {
+            uuid: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
+          },
         },
-      },
-      response: {},
-    };
+        response: {},
+      };
 
-    const processedValue = await actionParameterHandler.handle(action, param);
+      const processedValue = await actionParameterHandler.handle(action, param);
 
-    expect(processedValue).to.be.eq(action.request.params.uuid);
-  });
+      expect(processedValue).to.be.eq(action.request.params.uuid);
+    });
 
-  it('handle - should process string parameters, returns empty if a given string is empty', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata('uuid');
-
-    const action = {
-      request: {
-        params: {
-          uuid: '',
+    it('handle - should process string parameters, returns empty if a given string is empty', async () => {
+      const param = buildParamMetadata('uuid');
+      const action = {
+        request: {
+          params: {
+            uuid: '',
+          },
         },
-      },
-      response: {},
-    };
+        response: {},
+      };
 
-    const processedValue = await actionParameterHandler.handle(action, param);
+      const processedValue = await actionParameterHandler.handle(action, param);
 
-    expect(processedValue).to.be.eq(action.request.params.uuid);
-  });
+      expect(processedValue).to.be.eq(action.request.params.uuid);
+    });
 
-  it('handle - should process number parameters', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata('id');
-
-    const action = {
-      request: {
-        params: {
-          id: 10000,
+    it('handle - should process number parameters', async () => {
+      const param = buildParamMetadata('id');
+      const action = {
+        request: {
+          params: {
+            id: 10000,
+          },
         },
-      },
-      response: {},
-    };
+        response: {},
+      };
 
-    const processedValue = await actionParameterHandler.handle(action, param);
+      const processedValue = await actionParameterHandler.handle(action, param);
 
-    expect(processedValue).to.be.eq(action.request.params.id);
+      expect(processedValue).to.be.eq(action.request.params.id);
+    });
+
+    it('handle - undefined on empty object provided', async () => {
+      const param = buildParamMetadata();
+      const action = {
+        request: {
+          params: {},
+        },
+        response: {},
+      };
+
+      const processedValue = await actionParameterHandler.handle(action, param);
+
+      expect(processedValue).to.be.eq(undefined);
+    });
   });
+  describe('negative', () => {
+    it('handle - throws error if the parameter is required', async () => {
+      const param = buildParamMetadata('uuid', 'param', true);
+      const action = {
+        request: {},
+        response: {},
+      };
+      let error;
 
-  it('handle - undefined on empty object provided', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata();
+      try {
+        await actionParameterHandler.handle(action, param);
+      } catch (e) {
+        error = e;
+      }
 
-    const action = {
-      request: {
-        params: {},
-      },
-      response: {},
-    };
+      expect(error.toString()).to.be.eq("TypeError: Cannot read property 'uuid' of undefined");
+    });
 
-    const processedValue = await actionParameterHandler.handle(action, param);
+    it('handle - throws error if the parameter is required, type file provided', async () => {
+      const param = buildParamMetadata('uuid', 'file', true);
+      const action = {
+        request: {},
+        response: {},
+      };
+      let error;
 
-    expect(processedValue).to.be.eq(undefined);
-  });
+      try {
+        await actionParameterHandler.handle(action, param);
+      } catch (e) {
+        error = e;
+      }
 
-  it('handle - throws error if the parameter is required', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata('uuid', 'param', true);
-
-    const action = {
-      request: {},
-      response: {},
-    };
-    let error;
-
-    try {
-      await actionParameterHandler.handle(action, param);
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error.toString()).to.be.eq("TypeError: Cannot read property 'uuid' of undefined");
-  });
-
-  it('handle - throws error if the parameter is required, type file provided', async () => {
-    const driver = new ExpressDriver();
-    const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata('uuid', 'file', true);
-
-    const action = {
-      request: {},
-      response: {},
-    };
-    let error;
-
-    try {
-      await actionParameterHandler.handle(action, param);
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error.httpCode).to.be.eq(400);
-    expect(error.name).to.be.eq('ParamRequiredError');
-    expect(error.message).to.be.eq('Uploaded file "uuid" is required for request on undefined undefined');
+      expect(error.httpCode).to.be.eq(400);
+      expect(error.name).to.be.eq('ParamRequiredError');
+      expect(error.message).to.be.eq('Uploaded file "uuid" is required for request on undefined undefined');
+    });
   });
 });

--- a/test/ActionParameterHandler.spec.ts
+++ b/test/ActionParameterHandler.spec.ts
@@ -1,32 +1,30 @@
-import {ActionParameterHandler} from "../src/ActionParameterHandler";
-import {ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata} from "../src";
-import {ActionMetadataArgs} from "../src/metadata/args/ActionMetadataArgs";
-import {ControllerMetadataArgs} from "../src/metadata/args/ControllerMetadataArgs";
-import {ParamType} from "../src/metadata/types/ParamType";
+import { ActionParameterHandler } from '../src/ActionParameterHandler';
+import { ActionMetadata, ControllerMetadata, ExpressDriver, ParamMetadata } from '../src';
+import { ActionMetadataArgs } from '../src/metadata/args/ActionMetadataArgs';
+import { ControllerMetadataArgs } from '../src/metadata/args/ControllerMetadataArgs';
+import { ParamType } from '../src/metadata/types/ParamType';
 
-const expect = require("chakram").expect;
+const expect = require('chakram').expect;
 
-describe("ActionParameterHandler", () => {
+describe('ActionParameterHandler', () => {
   const buildParamMetadata = (
-      name: string = "id",
-      type: ParamType = "param",
-      isRequired: boolean = false,
+    name: string = 'id',
+    type: ParamType = 'param',
+    isRequired: boolean = false
   ): ParamMetadata => {
     const controllerMetadataArgs: ControllerMetadataArgs = {
-      target: function () {
-      },
-      route: "",
-      type: "json",
+      target: function () {},
+      route: '',
+      type: 'json',
       options: {},
     };
     const controllerMetadata = new ControllerMetadata(controllerMetadataArgs);
     const args: ActionMetadataArgs = {
-      route: "",
-      method: "getProduct",
+      route: '',
+      method: 'getProduct',
       options: {},
-      target: function () {
-      },
-      type: "get",
+      target: function () {},
+      type: 'get',
       appendParams: undefined,
     };
     const actionMetadata = new ActionMetadata(controllerMetadata, args, {});
@@ -34,13 +32,12 @@ describe("ActionParameterHandler", () => {
     return {
       type,
       name,
-      targetName: "product",
+      targetName: 'product',
       isTargetObject: true,
       actionMetadata,
-      target: () => {
-      },
-      method: "getProduct",
-      object: "getProduct",
+      target: () => {},
+      method: 'getProduct',
+      object: 'getProduct',
       extraOptions: undefined,
       index: 0,
       parse: undefined,
@@ -50,20 +47,19 @@ describe("ActionParameterHandler", () => {
       },
       classTransform: undefined,
       validate: undefined,
-      targetType: function () {
-      },
+      targetType: function () {},
     };
   };
 
-  it("handle - should process string parameters", async () => {
+  it('handle - should process string parameters', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata("uuid");
+    const param = buildParamMetadata('uuid');
 
     const action = {
       request: {
         params: {
-          uuid: "0b5ec98f-e26d-4414-b798-dcd35a5ef859",
+          uuid: '0b5ec98f-e26d-4414-b798-dcd35a5ef859',
         },
       },
       response: {},
@@ -74,15 +70,15 @@ describe("ActionParameterHandler", () => {
     expect(processedValue).to.be.eq(action.request.params.uuid);
   });
 
-  it("handle - should process string parameters, returns empty if a given string is empty", async () => {
+  it('handle - should process string parameters, returns empty if a given string is empty', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata("uuid");
+    const param = buildParamMetadata('uuid');
 
     const action = {
       request: {
         params: {
-          uuid: "",
+          uuid: '',
         },
       },
       response: {},
@@ -93,10 +89,10 @@ describe("ActionParameterHandler", () => {
     expect(processedValue).to.be.eq(action.request.params.uuid);
   });
 
-  it("handle - should process number parameters", async () => {
+  it('handle - should process number parameters', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata("id");
+    const param = buildParamMetadata('id');
 
     const action = {
       request: {
@@ -112,7 +108,7 @@ describe("ActionParameterHandler", () => {
     expect(processedValue).to.be.eq(action.request.params.id);
   });
 
-  it("handle - undefined on empty object provided", async () => {
+  it('handle - undefined on empty object provided', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
     const param = buildParamMetadata();
@@ -129,10 +125,10 @@ describe("ActionParameterHandler", () => {
     expect(processedValue).to.be.eq(undefined);
   });
 
-  it("handle - throws error if the parameter is required", async () => {
+  it('handle - throws error if the parameter is required', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata("uuid", "param", true);
+    const param = buildParamMetadata('uuid', 'param', true);
 
     const action = {
       request: {},
@@ -146,13 +142,13 @@ describe("ActionParameterHandler", () => {
       error = e;
     }
 
-    expect(error.toString()).to.be.eq('TypeError: Cannot read property \'uuid\' of undefined');
+    expect(error.toString()).to.be.eq("TypeError: Cannot read property 'uuid' of undefined");
   });
 
-  it("handle - throws error if the parameter is required, type file provided", async () => {
+  it('handle - throws error if the parameter is required, type file provided', async () => {
     const driver = new ExpressDriver();
     const actionParameterHandler = new ActionParameterHandler(driver);
-    const param = buildParamMetadata("uuid", "file", true);
+    const param = buildParamMetadata('uuid', 'file', true);
 
     const action = {
       request: {},
@@ -167,8 +163,7 @@ describe("ActionParameterHandler", () => {
     }
 
     expect(error.httpCode).to.be.eq(400);
-    expect(error.name).to.be.eq("ParamRequiredError");
-    expect(error.message).to.be.eq("Uploaded file \"uuid\" is required for request on undefined undefined");
+    expect(error.name).to.be.eq('ParamRequiredError');
+    expect(error.message).to.be.eq('Uploaded file "uuid" is required for request on undefined undefined');
   });
-
 });


### PR DESCRIPTION
## Description
The usage of UUID instead of id in routes like http://0.0.0.0:3000/api/products/04879b32-c329-48d7-a652-818794b684f1
Is trying to build JSON object while returning a raw parameter(UUID) provided.

Ref: https://github.com/typestack/routing-controllers/issues/703

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [s] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
The conditions the inside `normalizeParamValue` now excluding "param" type, keeping UUID strings untouched
