### PR TITLE
docs: Update use of glob patterns in docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,10 @@ You can load all controllers from directories, by specifying array of directorie
 
 ```typescript
 import { createExpressServer } from 'routing-controllers';
+import path from 'path';
 
 createExpressServer({
-  controllers: [__dirname + '/controllers/*.js'],
+  controllers: [path.join(__dirname + '/controllers/*.js')],
 }).listen(3000); // register controllers routes in our express application
 ```
 
@@ -1086,10 +1087,12 @@ Also you can load middlewares from directories. Also you can use glob patterns:
 
 ```typescript
 import { createExpressServer } from 'routing-controllers';
+import path from 'path';
+
 createExpressServer({
-  controllers: [__dirname + '/controllers/**/*.js'],
-  middlewares: [__dirname + '/middlewares/**/*.js'],
-  interceptors: [__dirname + '/interceptors/**/*.js'],
+  controllers: [path.join(__dirname, '/controllers/**/*.js')],
+  middlewares: [path.join(__dirname, '/middlewares/**/*.js')],
+  interceptors: [path.join(__dirname, '/interceptors/**/*.js')],
 }).listen(3000);
 ```
 
@@ -1382,6 +1385,7 @@ Here is example how to integrate routing-controllers with [typedi](https://githu
 ```typescript
 import { createExpressServer, useContainer } from 'routing-controllers';
 import { Container } from 'typedi';
+import path from 'path';
 
 // its important to set container before any operation you do with routing-controllers,
 // including importing controllers
@@ -1389,9 +1393,9 @@ useContainer(Container);
 
 // create and run server
 createExpressServer({
-  controllers: [__dirname + '/controllers/*.js'],
-  middlewares: [__dirname + '/middlewares/*.js'],
-  interceptors: [__dirname + '/interceptors/*.js'],
+  controllers: [path.join(__dirname, '/controllers/*.js')],
+  middlewares: [path.join(__dirname, '/middlewares/*.js')],
+  interceptors: [path.join(__dirname, '/interceptors/*.js')],
 }).listen(3000);
 ```
 


### PR DESCRIPTION
## Description

The docs assume that routes will always be in a subfolder of express app which may not be true and in which case the docs could use a touchup.

E.g. in a hexagonal architecture, Express is considered an adapter and api routes are ports so you may need something like:
```ts
useExpressServer(this.app, {
  routePrefix: '/api',
  controllers: [path.join(__dirname, '../../ports/api/routes/**/*.*')],
});
```
## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
