### PR TITLE
fix: check if a number is NaN in ActionParameterHandler

### DIFF
--- a/src/ActionParameterHandler.ts
+++ b/src/ActionParameterHandler.ts
@@ -155,7 +155,7 @@ export class ActionParameterHandler<T extends BaseDriver> {
         }
 
         const valueNumber = +value;
-        if (valueNumber === NaN) {
+        if (Number.isNaN(valueNumber)) {
           throw new InvalidParamError(value, parameterName, parameterType);
         }
 


### PR DESCRIPTION
## Description

`@Param('id') id: number` is not validated and accepts `NaN` as value in case of invalid `id`.

For example, if the following URL is accessed (`http://example.com/users/asdf`), instead of throwing an error, the `id` value is parsed to `NaN`. `InvalidParamError(value, parameterName, parameterType)` should be thrown instead.

The problem is due to how the checking of the result of the cast operation is done. `NaN` is not equal to `NaN`. Because of this it is necessary to use `Number.isNaN()`.

**Example**

```
@JsonController('/users')
class UserController {

  @Get('/:id')
  get (@Param('id') id: number) {
    console.log(id);
  }
}
```

**Result**

`GET http://example.com/users/1234` -> `1234`
`GET http://example.com/users/asdf` -> `NaN`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #348
