### PR TITLE
fix: disable keepAlive in test requests until axios is fixed

### DIFF
--- a/test/utilities/axios.ts
+++ b/test/utilities/axios.ts
@@ -1,7 +1,7 @@
 import Axios, { AxiosInstance } from 'axios';
-import {Agent} from "http";
+import { Agent } from 'http';
 
 export const axios: AxiosInstance = Axios.create({
   baseURL: 'http://localhost:3001/',
-  httpAgent: new Agent({keepAlive: false}) // disable keepAlive until axios is fixed
+  httpAgent: new Agent({ keepAlive: false }), // disable keepAlive until axios is fixed
 });

--- a/test/utilities/axios.ts
+++ b/test/utilities/axios.ts
@@ -1,5 +1,7 @@
 import Axios, { AxiosInstance } from 'axios';
+import {Agent} from "http";
 
 export const axios: AxiosInstance = Axios.create({
   baseURL: 'http://localhost:3001/',
+  httpAgent: new Agent({keepAlive: false}) // disable keepAlive until axios is fixed
 });


### PR DESCRIPTION
## Description
Disable keepAlive for test requests until axios lib is fixed (currently trying to reuse disconnected sockets)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
Tests
