### PR TITLE
fix: normalize glob patterns for windows

### DIFF
--- a/src/util/importClassesFromDirectories.ts
+++ b/src/util/importClassesFromDirectories.ts
@@ -17,8 +17,9 @@ export function importClassesFromDirectories(directories: string[], formats = ['
   };
 
   const allFiles = directories.reduce((allDirs, dir) => {
+    // Replace \ with / for glob
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return allDirs.concat(require('glob').sync(path.normalize(dir)));
+    return allDirs.concat(require('glob').sync(path.normalize(dir).replace(/\\/g, '/')));
   }, [] as string[]);
 
   const dirs = allFiles


### PR DESCRIPTION
## Description
normalize glob patterns to use / instead \ for both windows and *nix.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #987, #980
