### PR TITLE
Fix: Remove trailing slash from route path in KoaDriver

### DIFF
--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -129,7 +129,12 @@ export class KoaDriver extends BaseDriver {
     const afterMiddlewares = this.prepareMiddlewares(uses.filter(use => use.afterAction));
 
     // prepare route and route handler function
-    const route = ActionMetadata.appendBaseRoute(this.routePrefix, actionMetadata.fullRoute);
+    let route = ActionMetadata.appendBaseRoute(this.routePrefix, actionMetadata.fullRoute);
+
+    if (route.length > 1 && route.endsWith('/')) {
+      route = route.substring(0, route.length - 1)
+    }
+
     const routeHandler = (context: any, next: () => Promise<any>) => {
       const options: Action = { request: context.request, response: context.response, context, next };
       return executeCallback(options);

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -131,6 +131,7 @@ export class KoaDriver extends BaseDriver {
     // prepare route and route handler function
     let route = ActionMetadata.appendBaseRoute(this.routePrefix, actionMetadata.fullRoute);
 
+    // @koa/router is strict about trailing slashes, allow accessing routes without them
     if (typeof route === 'string' && route.length > 1 && route.endsWith('/')) {
       route = route.substring(0, route.length - 1)
     }

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -131,7 +131,7 @@ export class KoaDriver extends BaseDriver {
     // prepare route and route handler function
     let route = ActionMetadata.appendBaseRoute(this.routePrefix, actionMetadata.fullRoute);
 
-    if (route.length > 1 && route.endsWith('/')) {
+    if (typeof route === 'string' && route.length > 1 && route.endsWith('/')) {
       route = route.substring(0, route.length - 1)
     }
 

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -133,7 +133,7 @@ export class KoaDriver extends BaseDriver {
 
     // @koa/router is strict about trailing slashes, allow accessing routes without them
     if (typeof route === 'string' && route.length > 1 && route.endsWith('/')) {
-      route = route.substring(0, route.length - 1)
+      route = route.substring(0, route.length - 1);
     }
 
     const routeHandler = (context: any, next: () => Promise<any>) => {

--- a/test/functional/koa-trailing-slash.spec.ts
+++ b/test/functional/koa-trailing-slash.spec.ts
@@ -1,0 +1,62 @@
+import { Server as HttpServer } from 'http';
+import HttpStatusCodes from 'http-status-codes';
+import { Controller } from '../../src/decorator/Controller';
+import { Get } from '../../src/decorator/Get';
+import { createKoaServer, getMetadataArgsStorage } from '../../src/index';
+import { axios } from '../utilities/axios';
+import DoneCallback = jest.DoneCallback;
+
+describe(``, () => {
+  let koaServer: HttpServer;
+
+  describe('koa trailing slashes', () => {
+    beforeEach((done: DoneCallback) => {
+      getMetadataArgsStorage().reset();
+
+      @Controller('/posts')
+      class PostController {
+        @Get('/')
+        getAll(): string {
+          return '<html><body>All posts</body></html>';
+        }
+
+        @Get('/:id(\\d+)')
+        getUserById(): string {
+          return '<html><body>One post</body></html>';
+        }
+
+        @Get(/\/categories\/(\d+)/)
+        getCategoryById(): string {
+          return '<html><body>One post category</body></html>';
+        }
+
+        @Get('/:postId(\\d+)/users/:userId(\\d+)')
+        getPostById(): string {
+          return '<html><body>One user</body></html>';
+        }
+      }
+
+      koaServer = createKoaServer().listen(3001, done)
+    });
+
+    afterEach((done: DoneCallback) => {
+      koaServer.close(done);
+    });
+
+    it('get should respond to request without a traling slash', async () => {
+      expect.assertions(3);
+      const response = await axios.get('/posts');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+      expect(response.data).toEqual('<html><body>All posts</body></html>');
+    });
+
+    it('get should respond to request with a traling slash', async () => {
+      expect.assertions(3);
+      const response = await axios.get('/posts/');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.headers['content-type']).toEqual('text/html; charset=utf-8');
+      expect(response.data).toEqual('<html><body>All posts</body></html>');
+    });
+  });
+});

--- a/test/functional/koa-trailing-slash.spec.ts
+++ b/test/functional/koa-trailing-slash.spec.ts
@@ -19,21 +19,6 @@ describe(``, () => {
         getAll(): string {
           return '<html><body>All posts</body></html>';
         }
-
-        @Get('/:id(\\d+)')
-        getUserById(): string {
-          return '<html><body>One post</body></html>';
-        }
-
-        @Get(/\/categories\/(\d+)/)
-        getCategoryById(): string {
-          return '<html><body>One post category</body></html>';
-        }
-
-        @Get('/:postId(\\d+)/users/:userId(\\d+)')
-        getPostById(): string {
-          return '<html><body>One user</body></html>';
-        }
       }
 
       koaServer = createKoaServer().listen(3001, done)

--- a/test/functional/koa-trailing-slash.spec.ts
+++ b/test/functional/koa-trailing-slash.spec.ts
@@ -21,7 +21,7 @@ describe(``, () => {
         }
       }
 
-      koaServer = createKoaServer().listen(3001, done)
+      koaServer = createKoaServer().listen(3001, done);
     });
 
     afterEach((done: DoneCallback) => {


### PR DESCRIPTION
## Description
Before the update, `@koa/router` allowed path declared with a trailing slash to be accessible both with or without trailing slash
```ts
router.get('/user/', handler)

// GET /user -> 200
// GET /user/ -> 200
```

After the update, only trailing slash path is accessible. This makes registering nested routes with `@Get('/')` infeasible, when one does not use trailing slashes for URLs.

```ts
@JsonController('/user')
export class UserController {
  @Get('/') // <-- this causes the route to become `/user/`
  getUser() {}
}
```

Proposed change, restricted in scope to affected KoaDriver only, removes the trailing slash if one appears in the route (aside from `/`). `@koa/router` allows such paths to be accessed both with and without trailing slash, as before.

Please note `@Get('/')` is what official tests are using, and it works just fine with express:
https://github.com/typestack/routing-controllers/blob/develop/test/functional/controller-base-routes.spec.ts#L18-L21

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
Fixes #1113
