### PR TITLE
fix: action metadata not garbled when processing

### DIFF
--- a/test/unit/controller-inheritance.spec.ts
+++ b/test/unit/controller-inheritance.spec.ts
@@ -26,6 +26,9 @@ describe('controller inheritance', () => {
     @Controller(`/derivative`)
     class DerivativeController extends AbstractControllerTemplate {}
 
+    @Controller(`/derivative2`)
+    class DerivativeController2 extends AbstractControllerTemplate {}
+
     @Controller(`/autonomous`)
     class AutonomousController {
       @Post()
@@ -39,9 +42,12 @@ describe('controller inheritance', () => {
 
     expect(storage.controllers[0].target).to.be.eq(DerivativeController);
     expect(storage.controllers[0].route).to.be.eq('/derivative');
-    expect(storage.controllers[1].target).to.be.eq(AutonomousController);
-    expect(storage.controllers[1].route).to.be.eq('/autonomous');
-    expect(storage.actions[0].target).to.be.eq(DerivativeController);
+    expect(storage.controllers[1].target).to.be.eq(DerivativeController2);
+    expect(storage.controllers[1].route).to.be.eq('/derivative2');
+    expect(storage.controllers[2].target).to.be.eq(AutonomousController);
+    expect(storage.controllers[2].route).to.be.eq('/autonomous');
+
+    expect(storage.actions[0].target).to.be.eq(AbstractControllerTemplate);
     expect(storage.actions[0].type).to.be.eq('post');
     expect(storage.actions[0].method).to.be.eq('create');
     expect(storage.actions[1].target).to.be.eq(AutonomousController);
@@ -125,7 +131,7 @@ describe('controller inheritance', () => {
     expect(storage.controllers[0].route).to.be.eq('/derivative');
     expect(storage.controllers[1].target).to.be.eq(AutonomousController);
     expect(storage.controllers[1].route).to.be.eq('/autonomous');
-    expect(storage.actions[0].target).to.be.eq(DerivativeController);
+    expect(storage.actions[0].target).to.be.eq(AbstractControllerTemplate);
     expect(storage.actions[0].type).to.be.eq('post');
     expect(storage.actions[0].method).to.be.eq('create');
     expect(storage.actions[1].target).to.be.eq(AutonomousController);


### PR DESCRIPTION
## Description
A more concise re-implementation of the `createActions()` method. Essence of this is that the `target` property of the metadata is not changed in-place, which hindered using a base class multiple times.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1124 
