### PR TITLE
fix: createActions should not garble baseclass metadata

### DIFF
--- a/src/metadata-builder/MetadataBuilder.ts
+++ b/src/metadata-builder/MetadataBuilder.ts
@@ -8,7 +8,6 @@ import { ResponseHandlerMetadata } from '../metadata/ResponseHandleMetadata';
 import { RoutingControllersOptions } from '../RoutingControllersOptions';
 import { UseMetadata } from '../metadata/UseMetadata';
 import { getMetadataArgsStorage } from '../index';
-import { ActionMetadataArgs } from '../metadata/args/ActionMetadataArgs';
 
 /**
  * Builds metadata from the given metadata arguments.

--- a/src/metadata-builder/MetadataBuilder.ts
+++ b/src/metadata-builder/MetadataBuilder.ts
@@ -92,33 +92,25 @@ export class MetadataBuilder {
    * Creates action metadatas.
    */
   protected createActions(controller: ControllerMetadata): ActionMetadata[] {
-    let target = controller.target;
-    const actionsWithTarget: ActionMetadataArgs[] = [];
-    while (target) {
-      const actions = getMetadataArgsStorage()
-        .filterActionsWithTarget(target)
-        .filter(action => {
-          return actionsWithTarget.map(a => a.method).indexOf(action.method) === -1;
+    const actionsWithTarget: ActionMetadata[] = [];
+    for (let target = controller.target; target; target = Object.getPrototypeOf(target)) {
+      const actions = getMetadataArgsStorage().filterActionsWithTarget(target);
+      const methods = actionsWithTarget.map(a => a.method);
+      actions
+        .filter(({ method }) => !methods.includes(method))
+        .forEach(actionArgs => {
+          const action = new ActionMetadata(controller, { ...actionArgs, target: controller.target }, this.options);
+          action.options = { ...controller.options, ...actionArgs.options };
+          action.params = this.createParams(action);
+          action.uses = this.createActionUses(action);
+          action.interceptors = this.createActionInterceptorUses(action);
+          action.build(this.createActionResponseHandlers(action));
+
+          actionsWithTarget.push(action);
         });
-
-      actions.forEach(a => {
-        a.target = controller.target;
-
-        actionsWithTarget.push(a);
-      });
-
-      target = Object.getPrototypeOf(target);
     }
 
-    return actionsWithTarget.map(actionArgs => {
-      const action = new ActionMetadata(controller, actionArgs, this.options);
-      action.options = { ...controller.options, ...actionArgs.options };
-      action.params = this.createParams(action);
-      action.uses = this.createActionUses(action);
-      action.interceptors = this.createActionInterceptorUses(action);
-      action.build(this.createActionResponseHandlers(action));
-      return action;
-    });
+    return actionsWithTarget;
   }
 
   /**

--- a/test/unit/controller-inheritance.spec.ts
+++ b/test/unit/controller-inheritance.spec.ts
@@ -26,6 +26,9 @@ describe('controller inheritance', () => {
     @Controller(`/derivative`)
     class DerivativeController extends AbstractControllerTemplate {}
 
+    @Controller(`/derivative2`)
+    class DerivativeController2 extends AbstractControllerTemplate {}
+
     @Controller(`/autonomous`)
     class AutonomousController {
       @Post()
@@ -39,9 +42,12 @@ describe('controller inheritance', () => {
 
     expect(storage.controllers[0].target).to.be.eq(DerivativeController);
     expect(storage.controllers[0].route).to.be.eq('/derivative');
-    expect(storage.controllers[1].target).to.be.eq(AutonomousController);
-    expect(storage.controllers[1].route).to.be.eq('/autonomous');
-    expect(storage.actions[0].target).to.be.eq(DerivativeController);
+    expect(storage.controllers[1].target).to.be.eq(DerivativeController2);
+    expect(storage.controllers[1].route).to.be.eq('/derivative2');
+    expect(storage.controllers[2].target).to.be.eq(AutonomousController);
+    expect(storage.controllers[2].route).to.be.eq('/autonomous');
+
+    expect(storage.actions[0].target).to.be.eq(AbstractControllerTemplate);
     expect(storage.actions[0].type).to.be.eq('post');
     expect(storage.actions[0].method).to.be.eq('create');
     expect(storage.actions[1].target).to.be.eq(AutonomousController);
@@ -125,7 +131,7 @@ describe('controller inheritance', () => {
     expect(storage.controllers[0].route).to.be.eq('/derivative');
     expect(storage.controllers[1].target).to.be.eq(AutonomousController);
     expect(storage.controllers[1].route).to.be.eq('/autonomous');
-    expect(storage.actions[0].target).to.be.eq(DerivativeController);
+    expect(storage.actions[0].target).to.be.eq(AbstractControllerTemplate);
     expect(storage.actions[0].type).to.be.eq('post');
     expect(storage.actions[0].method).to.be.eq('create');
     expect(storage.actions[1].target).to.be.eq(AutonomousController);


### PR DESCRIPTION
## Description
A more concise re-implementation of the `createActions()` method. Essence of this is that the `target` property of the metadata is not changed in-place, which hindered using a base class multiple times.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1124 