### PR TITLE
Upgrade the cookie version to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.2",
         "glob": "^11.0.0",
         "reflect-metadata": "^0.2.2",
         "template-url": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:debug": "NODE_ENV= node --inspect=0.0.0.0:20001 ./node_modules/.bin/jest --colors --runInBand --no-coverage --watch"
   },
   "dependencies": {
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.2",
     "glob": "^11.0.0",
     "reflect-metadata": "^0.2.2",
     "template-url": "^1.0.0"


### PR DESCRIPTION
I updated the package-lock.json and package.json file , to change the version of the cookie package from 0.6.0 to 0.7.2 to patch this vulnerability [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764)