### PR TITLE
feat: optional wildcard routing in routePrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,18 +331,89 @@ createExpressServer({
 
 #### Prefix all controllers routes
 
-If you want to prefix all your routes, e.g. `/api` you can use `routePrefix` option:
+You can prefix all your routes using the `routePrefix` option. This supports three types of patterns:
 
+1. Simple string prefix:
 ```typescript
 import { createExpressServer } from 'routing-controllers';
-import { UserController } from './controller/UserController';
 
 createExpressServer({
   routePrefix: '/api',
   controllers: [UserController],
 }).listen(3000);
 ```
+> koa users must use `createKoaServer` instead of `createExpressServer`
 
+2. Wildcard patterns for dynamic segments:
+
+**Match single segment: /dev/api, /staging/api, etc.**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+    routePrefix: '/*/api',
+    controllers: [UserController],
+}).listen(3000);
+```
+> koa users must use `createKoaServer` instead of `createExpressServer`
+
+**Match an optional segment: /api or /staging/api**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+    routePrefix: '/*?',
+    controllers: [UserController],
+}).listen(3000);
+```
+> koa users must use `createKoaServer` instead of `createExpressServer`
+
+**Match multiple segments: /v1/staging/api, /v2/prod/api, etc.**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+    routePrefix: '/*/*/api',
+    controllers: [UserController],
+}).listen(3000);
+```
+> koa users must use `createKoaServer` instead of `createExpressServer`
+
+
+**Mix fixed and wildcard segments: /api/region1/v2/instance2/service**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+  routePrefix: '/api/*/v2/*/service',
+  controllers: [UserController],
+}).listen(3000);
+```
+> koa users must use `createKoaServer` instead of `createExpressServer`
+
+
+3. Regular expressions for complex patterns:
+
+**Match version numbers: /v1/api, /v2/api, etc.**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+    routePrefix: /\/v[0-9]+\/api/,
+    controllers: [UserController],
+}).listen(3000);
+```
+> koa users must use `createKoaServer` instead of `createExpressServer`
+
+**Optional segments: /api or /api/v1**
+```typescript
+import { createExpressServer } from 'routing-controllers';
+
+createExpressServer({
+    routePrefix: /\/api(\/v[0-9]+)?/,
+    controllers: [UserController],
+}).listen(3000);
+```
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 #### Prefix controller with base route

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ createExpressServer({
 You can prefix all your routes using the `routePrefix` option. This supports three types of patterns:
 
 1. Simple string prefix:
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
@@ -342,45 +343,52 @@ createExpressServer({
   controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 2. Wildcard patterns for dynamic segments:
 
 **Match single segment: /dev/api, /staging/api, etc.**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
 createExpressServer({
-    routePrefix: '/*/api',
-    controllers: [UserController],
+  routePrefix: '/*/api',
+  controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 **Match an optional segment: /api or /staging/api**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
 createExpressServer({
-    routePrefix: '/*?',
-    controllers: [UserController],
+  routePrefix: '/*?',
+  controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 **Match multiple segments: /v1/staging/api, /v2/prod/api, etc.**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
 createExpressServer({
-    routePrefix: '/*/*/api',
-    controllers: [UserController],
+  routePrefix: '/*/*/api',
+  controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
-
 **Mix fixed and wildcard segments: /api/region1/v2/instance2/service**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
@@ -389,31 +397,35 @@ createExpressServer({
   controllers: [UserController],
 }).listen(3000);
 ```
-> koa users must use `createKoaServer` instead of `createExpressServer`
 
+> koa users must use `createKoaServer` instead of `createExpressServer`
 
 3. Regular expressions for complex patterns:
 
 **Match version numbers: /v1/api, /v2/api, etc.**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
 createExpressServer({
-    routePrefix: /\/v[0-9]+\/api/,
-    controllers: [UserController],
+  routePrefix: /\/v[0-9]+\/api/,
+  controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 **Optional segments: /api or /api/v1**
+
 ```typescript
 import { createExpressServer } from 'routing-controllers';
 
 createExpressServer({
-    routePrefix: /\/api(\/v[0-9]+)?/,
-    controllers: [UserController],
+  routePrefix: /\/api(\/v[0-9]+)?/,
+  controllers: [UserController],
 }).listen(3000);
 ```
+
 > koa users must use `createKoaServer` instead of `createExpressServer`
 
 #### Prefix controller with base route

--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -18,6 +18,7 @@ export interface RoutingControllersOptions {
    * Can be either:
    * - a string (e.g. '/api')
    * - a RegExp pattern for dynamic matching
+   * - a wildcard string (e.g. "/*\/api")
    */
   routePrefix?: string | RegExp;
 

--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -14,9 +14,12 @@ export interface RoutingControllersOptions {
   cors?: boolean | Object;
 
   /**
-   * Global route prefix, for example '/api'.
+   * Global route prefix.
+   * Can be either:
+   * - a string (e.g. '/api')
+   * - a RegExp pattern for dynamic matching
    */
-  routePrefix?: string;
+  routePrefix?: string | RegExp;
 
   /**
    * List of controllers to register in the framework or directories from where to import all your controllers.

--- a/src/decorator/Get.ts
+++ b/src/decorator/Get.ts
@@ -1,5 +1,6 @@
-import { HandlerOptions } from '../decorator-options/HandlerOptions';
+import type { HandlerOptions } from '../decorator-options/HandlerOptions';
 import { getMetadataArgsStorage } from '../index';
+import type { ActionMetadataArgs } from '../metadata/args/ActionMetadataArgs';
 
 /**
  * Registers an action to be executed when GET request comes on a given route.
@@ -19,7 +20,7 @@ export function Get(route?: string, options?: HandlerOptions): Function;
  */
 export function Get(route?: string | RegExp, options?: HandlerOptions): Function {
   return function (object: Object, methodName: string) {
-    getMetadataArgsStorage().actions.push({
+    getMetadataArgsStorage().actions.push(<ActionMetadataArgs>{
       type: 'get',
       target: object.constructor,
       method: methodName,

--- a/src/driver/BaseDriver.ts
+++ b/src/driver/BaseDriver.ts
@@ -64,7 +64,7 @@ export abstract class BaseDriver {
   /**
    * Global application prefix.
    */
-  routePrefix: string = '';
+  routePrefix: string | RegExp = '';
 
   /**
    * Indicates if cors are enabled.

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -12,6 +12,7 @@ import { isPromiseLike } from '../../util/isPromiseLike';
 import { getFromContainer } from '../../container';
 import { AuthorizationRequiredError } from '../../error/AuthorizationRequiredError';
 import { NotFoundError, RoutingControllersOptions } from '../../index';
+import type { Express } from 'express';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const cookie = require('cookie');
@@ -26,7 +27,7 @@ export class ExpressDriver extends BaseDriver {
   // Constructor
   // -------------------------------------------------------------------------
 
-  constructor(public express?: any) {
+  constructor(public express?: Express) {
     super();
     this.loadExpress();
     this.app = this.express;
@@ -44,9 +45,9 @@ export class ExpressDriver extends BaseDriver {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const cors = require('cors');
       if (this.cors === true) {
-        this.express.use(cors());
+        this.express?.use(cors());
       } else {
-        this.express.use(cors(this.cors));
+        this.express?.use(cors(this.cors));
       }
     }
   }
@@ -88,7 +89,7 @@ export class ExpressDriver extends BaseDriver {
         writable: true,
       });
 
-      this.express.use(options.routePrefix || '/', middlewareWrapper);
+      this.express?.use(options.routePrefix || '/', middlewareWrapper);
     }
   }
 
@@ -181,7 +182,7 @@ export class ExpressDriver extends BaseDriver {
     };
 
     // finally register action in express
-    this.express[actionMetadata.type.toLowerCase()](
+    this.express?.[actionMetadata.type.toLowerCase()](
       ...[route, routeGuard, ...beforeMiddlewares, ...defaultMiddlewares, routeHandler, ...afterMiddlewares]
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { RoutingControllers } from './RoutingControllers';
 import { RoutingControllersOptions } from './RoutingControllersOptions';
 import { ValidationOptions } from 'class-validator';
 import { importClassesFromDirectories } from './util/importClassesFromDirectories';
+import type { Express } from 'express';
 
 // -------------------------------------------------------------------------
 // Main exports
@@ -116,7 +117,7 @@ export function getMetadataArgsStorage(): MetadataArgsStorage {
  * Registers all loaded actions in your express application.
  */
 export function useExpressServer<T>(expressServer: T, options?: RoutingControllersOptions): T {
-  const driver = new ExpressDriver(expressServer);
+  const driver = new ExpressDriver(expressServer as Express);
   return createServer(driver, options);
 }
 
@@ -157,19 +158,19 @@ export function createServer<T extends BaseDriver>(driver: T, options?: RoutingC
  */
 export function createExecutor<T extends BaseDriver>(driver: T, options: RoutingControllersOptions = {}): void {
   // import all controllers and middlewares and error handlers (new way)
-  let controllerClasses: Function[];
+  let controllerClasses: Function[] = [];
   if (options && options.controllers && options.controllers.length) {
     controllerClasses = (options.controllers as any[]).filter(controller => controller instanceof Function);
     const controllerDirs = (options.controllers as any[]).filter(controller => typeof controller === 'string');
     controllerClasses.push(...importClassesFromDirectories(controllerDirs));
   }
-  let middlewareClasses: Function[];
+  let middlewareClasses: Function[] = [];
   if (options && options.middlewares && options.middlewares.length) {
     middlewareClasses = (options.middlewares as any[]).filter(controller => controller instanceof Function);
     const middlewareDirs = (options.middlewares as any[]).filter(controller => typeof controller === 'string');
     middlewareClasses.push(...importClassesFromDirectories(middlewareDirs));
   }
-  let interceptorClasses: Function[];
+  let interceptorClasses: Function[] = [];
   if (options && options.interceptors && options.interceptors.length) {
     interceptorClasses = (options.interceptors as any[]).filter(controller => controller instanceof Function);
     const interceptorDirs = (options.interceptors as any[]).filter(controller => typeof controller === 'string');
@@ -201,8 +202,8 @@ export function createExecutor<T extends BaseDriver>(driver: T, options: Routing
     driver.enableValidation = true;
   }
 
-  driver.classToPlainTransformOptions = options.classToPlainTransformOptions;
-  driver.plainToClassTransformOptions = options.plainToClassTransformOptions;
+  if (options.classToPlainTransformOptions) driver.classToPlainTransformOptions = options.classToPlainTransformOptions;
+  if (options.plainToClassTransformOptions) driver.plainToClassTransformOptions = options.plainToClassTransformOptions;
 
   if (options.errorOverridingMap !== undefined) driver.errorOverridingMap = options.errorOverridingMap;
 
@@ -234,7 +235,7 @@ export function createParamDecorator(options: CustomParameterDecorator) {
       method: method,
       index: index,
       parse: false,
-      required: options.required,
+      required: !!options.required,
       transform: options.value,
     });
   };

--- a/src/metadata-builder/MetadataArgsStorage.ts
+++ b/src/metadata-builder/MetadataArgsStorage.ts
@@ -103,7 +103,10 @@ export class MetadataArgsStorage {
   /**
    * Filters registered "use interceptors" by a given target class and method name.
    */
-  filterInterceptorUsesWithTargetAndMethod(target: Function, methodName: string | undefined): UseInterceptorMetadataArgs[] {
+  filterInterceptorUsesWithTargetAndMethod(
+    target: Function,
+    methodName: string | undefined
+  ): UseInterceptorMetadataArgs[] {
     return this.useInterceptors.filter(use => {
       return use.target === target && use.method === methodName;
     });

--- a/src/metadata-builder/MetadataArgsStorage.ts
+++ b/src/metadata-builder/MetadataArgsStorage.ts
@@ -94,7 +94,7 @@ export class MetadataArgsStorage {
   /**
    * Filters registered "use middlewares" by a given target class and method name.
    */
-  filterUsesWithTargetAndMethod(target: Function, methodName: string): UseMetadataArgs[] {
+  filterUsesWithTargetAndMethod(target: Function, methodName: string | undefined): UseMetadataArgs[] {
     return this.uses.filter(use => {
       return use.target === target && use.method === methodName;
     });
@@ -103,7 +103,7 @@ export class MetadataArgsStorage {
   /**
    * Filters registered "use interceptors" by a given target class and method name.
    */
-  filterInterceptorUsesWithTargetAndMethod(target: Function, methodName: string): UseInterceptorMetadataArgs[] {
+  filterInterceptorUsesWithTargetAndMethod(target: Function, methodName: string | undefined): UseInterceptorMetadataArgs[] {
     return this.useInterceptors.filter(use => {
       return use.target === target && use.method === methodName;
     });

--- a/src/metadata-builder/MetadataBuilder.ts
+++ b/src/metadata-builder/MetadataBuilder.ts
@@ -48,7 +48,7 @@ export class MetadataBuilder {
    * Creates middleware metadatas.
    */
   protected createMiddlewares(classes?: Function[]): MiddlewareMetadata[] {
-    const middlewares = !classes
+    const middlewares = !classes || classes.length === 0
       ? getMetadataArgsStorage().middlewares
       : getMetadataArgsStorage().filterMiddlewareMetadatasForClasses(classes);
     return middlewares.map(middlewareArgs => new MiddlewareMetadata(middlewareArgs));
@@ -58,7 +58,7 @@ export class MetadataBuilder {
    * Creates interceptor metadatas.
    */
   protected createInterceptors(classes?: Function[]): InterceptorMetadata[] {
-    const interceptors = !classes
+    const interceptors = !classes || classes.length === 0
       ? getMetadataArgsStorage().interceptors
       : getMetadataArgsStorage().filterInterceptorMetadatasForClasses(classes);
     return interceptors.map(
@@ -74,7 +74,7 @@ export class MetadataBuilder {
    * Creates controller metadatas.
    */
   protected createControllers(classes?: Function[]): ControllerMetadata[] {
-    const controllers = !classes
+    const controllers = !classes || classes.length === 0
       ? getMetadataArgsStorage().controllers
       : getMetadataArgsStorage().filterControllerMetadatasForClasses(classes);
     return controllers.map(controllerArgs => {

--- a/src/metadata-builder/MetadataBuilder.ts
+++ b/src/metadata-builder/MetadataBuilder.ts
@@ -48,9 +48,10 @@ export class MetadataBuilder {
    * Creates middleware metadatas.
    */
   protected createMiddlewares(classes?: Function[]): MiddlewareMetadata[] {
-    const middlewares = !classes || classes.length === 0
-      ? getMetadataArgsStorage().middlewares
-      : getMetadataArgsStorage().filterMiddlewareMetadatasForClasses(classes);
+    const middlewares =
+      !classes || classes.length === 0
+        ? getMetadataArgsStorage().middlewares
+        : getMetadataArgsStorage().filterMiddlewareMetadatasForClasses(classes);
     return middlewares.map(middlewareArgs => new MiddlewareMetadata(middlewareArgs));
   }
 
@@ -58,9 +59,10 @@ export class MetadataBuilder {
    * Creates interceptor metadatas.
    */
   protected createInterceptors(classes?: Function[]): InterceptorMetadata[] {
-    const interceptors = !classes || classes.length === 0
-      ? getMetadataArgsStorage().interceptors
-      : getMetadataArgsStorage().filterInterceptorMetadatasForClasses(classes);
+    const interceptors =
+      !classes || classes.length === 0
+        ? getMetadataArgsStorage().interceptors
+        : getMetadataArgsStorage().filterInterceptorMetadatasForClasses(classes);
     return interceptors.map(
       interceptorArgs =>
         new InterceptorMetadata({
@@ -74,9 +76,10 @@ export class MetadataBuilder {
    * Creates controller metadatas.
    */
   protected createControllers(classes?: Function[]): ControllerMetadata[] {
-    const controllers = !classes || classes.length === 0
-      ? getMetadataArgsStorage().controllers
-      : getMetadataArgsStorage().filterControllerMetadatasForClasses(classes);
+    const controllers =
+      !classes || classes.length === 0
+        ? getMetadataArgsStorage().controllers
+        : getMetadataArgsStorage().filterControllerMetadatasForClasses(classes);
     return controllers.map(controllerArgs => {
       const controller = new ControllerMetadata(controllerArgs);
       controller.build(this.createControllerResponseHandlers(controller));

--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -220,9 +220,7 @@ export class ActionMetadata {
       return new RegExp('^(?:/[^/]+)?');
     }
 
-    const escapedPattern = pattern
-      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-      .replace(/\*/g, '[^/]+');
+    const escapedPattern = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]+');
 
     return new RegExp(`^${escapedPattern}`);
   }

--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -175,14 +175,28 @@ export class ActionMetadata {
   /**
    * Appends base route to a given regexp route.
    */
-  static appendBaseRoute(baseRoute: string, route: RegExp | string) {
+  /**
+   * Appends base route to a given regexp route.
+   */
+  static appendBaseRoute(baseRoute: string | RegExp, route: RegExp | string) {
+    // If baseRoute is RegExp
+    if (baseRoute instanceof RegExp) {
+      const basePattern = baseRoute.source;
+
+      if (typeof route === 'string') {
+        // RegExp base + string route
+        return new RegExp(`${basePattern}${route}`, baseRoute.flags);
+      }
+      // RegExp base + RegExp route
+      return new RegExp(`${basePattern}${route.source}`, `${baseRoute.flags}${route.flags}`);
+    }
+
     const prefix = `${baseRoute.length > 0 && baseRoute.indexOf('/') < 0 ? '/' : ''}${baseRoute}`;
     if (typeof route === 'string') return `${prefix}${route}`;
 
     if (!baseRoute || baseRoute === '') return route;
 
     const fullPath = `^${prefix}${route.toString().substr(1)}?$`;
-
     return new RegExp(fullPath, route.flags);
   }
 

--- a/test/functional/route-prefix-regexp.spec.ts
+++ b/test/functional/route-prefix-regexp.spec.ts
@@ -130,7 +130,7 @@ describe('routePrefix functionality', () => {
 
       expressServer = createExpressServer({
         controllers: [TestController],
-        routePrefix: '/*/api'
+        routePrefix: '/*/api',
       }).listen(3001, done);
     });
 
@@ -172,7 +172,7 @@ describe('routePrefix functionality', () => {
 
       expressServer = createExpressServer({
         controllers: [TestController],
-        routePrefix: '/*/*/api'
+        routePrefix: '/*/*/api',
       }).listen(3001, done);
     });
 
@@ -216,7 +216,7 @@ describe('routePrefix functionality', () => {
 
       expressServer = createExpressServer({
         controllers: [TestController],
-        routePrefix: '/api/*/v2/*/service'
+        routePrefix: '/api/*/v2/*/service',
       }).listen(3001, async () => {
         const response = await axios.get('/api/region1/v2/instance2/service/test');
         expect(response.status).toEqual(HttpStatusCodes.OK);
@@ -236,7 +236,7 @@ describe('routePrefix functionality', () => {
 
       expressServer = createExpressServer({
         controllers: [TestController],
-        routePrefix: '/*/api/v2'
+        routePrefix: '/*/api/v2',
       }).listen(3001, async () => {
         const response = await axios.get('/dev/api/v2/test');
         expect(response.status).toEqual(HttpStatusCodes.OK);
@@ -260,7 +260,7 @@ describe('routePrefix functionality', () => {
 
       expressServer = createExpressServer({
         controllers: [TestController],
-        routePrefix: '/*?/defects'
+        routePrefix: '/*?/defects',
       }).listen(3001, done);
     });
 
@@ -284,7 +284,6 @@ describe('routePrefix functionality', () => {
       expect(response2.status).toEqual(HttpStatusCodes.OK);
     });
   });
-
 
   describe('edge cases', () => {
     beforeEach(() => {

--- a/test/functional/route-prefix-regexp.spec.ts
+++ b/test/functional/route-prefix-regexp.spec.ts
@@ -1,0 +1,182 @@
+import { Server as HttpServer } from 'http';
+import HttpStatusCodes from 'http-status-codes';
+import { createExpressServer, Get, getMetadataArgsStorage, JsonController } from '../../src';
+import { axios } from '../utilities/axios';
+import DoneCallback = jest.DoneCallback;
+
+describe('routePrefix functionality', () => {
+  let expressServer: HttpServer;
+
+  afterEach((done: DoneCallback) => {
+    if (expressServer) {
+      expressServer.close(done);
+    } else {
+      done();
+    }
+  });
+
+  describe('string routePrefix', () => {
+    beforeEach((done: DoneCallback) => {
+      getMetadataArgsStorage().reset();
+
+      @JsonController()
+      class TestController {
+        @Get('/test')
+        test() {
+          return { status: 'success' };
+        }
+
+        @Get('/nested/route')
+        nested() {
+          return { status: 'nested' };
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [TestController],
+        routePrefix: '/api',
+      }).listen(3001, done);
+    });
+
+    it('should work with basic string prefix', async () => {
+      const response = await axios.get('/api/test');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.data).toEqual({ status: 'success' });
+    });
+
+    it('should work with nested routes', async () => {
+      const response = await axios.get('/api/nested/route');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.data).toEqual({ status: 'nested' });
+    });
+
+    it('should 404 on wrong prefix', async () => {
+      try {
+        await axios.get('/wrong/test');
+        fail('Should not reach here');
+      } catch (error) {
+        expect(error.response.status).toEqual(HttpStatusCodes.NOT_FOUND);
+      }
+    });
+  });
+
+  describe('RegExp routePrefix', () => {
+    beforeEach((done: DoneCallback) => {
+      getMetadataArgsStorage().reset();
+
+      @JsonController()
+      class TestController {
+        @Get('/test')
+        test() {
+          return { status: 'success' };
+        }
+
+        @Get('/nested/route')
+        nested() {
+          return { status: 'nested' };
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [TestController],
+        routePrefix: /\/.*\/api/,
+      }).listen(3001, done);
+    });
+
+    it('should match simple dynamic prefix', async () => {
+      const response = await axios.get('/dev/api/test');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.data).toEqual({ status: 'success' });
+    });
+
+    it('should match multiple segments in dynamic prefix', async () => {
+      const response = await axios.get('/staging/v1/api/test');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.data).toEqual({ status: 'success' });
+    });
+
+    it('should work with nested routes', async () => {
+      const response = await axios.get('/dev/api/nested/route');
+      expect(response.status).toEqual(HttpStatusCodes.OK);
+      expect(response.data).toEqual({ status: 'nested' });
+    });
+
+    it('should 404 on non-matching regex pattern', async () => {
+      try {
+        await axios.get('/dev/wrong/test');
+        fail('Should not reach here');
+      } catch (error) {
+        expect(error.response.status).toEqual(HttpStatusCodes.NOT_FOUND);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      getMetadataArgsStorage().reset();
+    });
+
+    it('should work with empty routePrefix', (done: DoneCallback) => {
+      @JsonController()
+      class TestController {
+        @Get('/test')
+        test() {
+          return { status: 'success' };
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [TestController],
+        routePrefix: '',
+      }).listen(3001, async () => {
+        const response = await axios.get('/test');
+        expect(response.status).toEqual(HttpStatusCodes.OK);
+        expect(response.data).toEqual({ status: 'success' });
+        done();
+      });
+    });
+
+    it('should work with complex regex patterns', (done: DoneCallback) => {
+      @JsonController()
+      class TestController {
+        @Get('/test')
+        test() {
+          return { status: 'success' };
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [TestController],
+        routePrefix: /\/v[0-9]+\/[a-z]+\/api/,
+      }).listen(3001, async () => {
+        const response = await axios.get('/v1/stage/api/test');
+        expect(response.status).toEqual(HttpStatusCodes.OK);
+        expect(response.data).toEqual({ status: 'success' });
+        done();
+      });
+    });
+
+    it('should handle regex with optional groups', (done: DoneCallback) => {
+      @JsonController()
+      class TestController {
+        @Get('/test')
+        test() {
+          return { status: 'success' };
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [TestController],
+        routePrefix: /\/api(\/v[0-9]+)?/,
+      }).listen(3001, async () => {
+        // Should match both with and without version
+        const response1 = await axios.get('/api/test');
+        expect(response1.status).toEqual(HttpStatusCodes.OK);
+
+        const response2 = await axios.get('/api/v1/test');
+        expect(response2.status).toEqual(HttpStatusCodes.OK);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Introduce more complex route prefix wildcard ability

## Problem
When using routing-controllers with API Gateway and custom domain names, path segments can be conditionally present. For example, a route might be accessed as both `/endpoint` (direct) and `/custom-domain/endpoint` (via custom domain). The current routing-controllers implementation doesn't support this kind of optional path segment matching.

## Solution
Enhanced the `routePrefix` feature to support:
1. RegExp patterns for complex matching
2. Wildcard string patterns (`*`) for single segment matching
3. Optional wildcard patterns (`*?`) for optional segment matching

## Changes
- Updated `RoutingControllersOptions` interface to support RegExp for routePrefix
- Added `convertWildcardToRegex` function to handle wildcard patterns
- Modified `appendBaseRoute` to process both RegExp and wildcard patterns
- Corrected minimal amount of typing around proposed changes
- Added additional tests for all new pattern types
- Updated documentation with examples

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
